### PR TITLE
Feature - Test Suite Cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ All notable changes to this project will be documented in this file.
 
 - A new `TableLockPolicy` to handle table lock errors on `execute`, `prepare`, and `step` operations.
 
+#### Updated
+
+- The test suite by replacing `do-catch` implementations with `throws` test API variants and unhelpful assertion strings.
+
 ---
 
 ## [3.1.0](https://github.com/Nike-Inc/SQift/releases/tag/3.1.0)

--- a/Tests/Tests/Connection/ConnectionPoolTests.swift
+++ b/Tests/Tests/Connection/ConnectionPoolTests.swift
@@ -42,99 +42,83 @@ class ConnectionPoolTestCase: BaseTestCase {
             XCTFail("Execution should not reach this point")
         } catch let error as SQLiteError {
             // Then
-            XCTAssertEqual(error.code, SQLITE_CANTOPEN, "error code should be `SQLITE_CANTOPEN`")
+            XCTAssertEqual(error.code, SQLITE_CANTOPEN)
         } catch {
             XCTFail("Failed with an unknown error type: \(error)")
         }
     }
 
-    func testThatDequeueingConnectionCreatesNewConnection() {
-        do {
-            // Given
-            let pool = ConnectionPool(storageLocation: storageLocation)
-            pool.availableConnections.removeAll()
+    func testThatDequeueingConnectionCreatesNewConnection() throws {
+        // Given
+        let pool = ConnectionPool(storageLocation: storageLocation)
+        pool.availableConnections.removeAll()
 
-            // When
-            let connection = try pool.dequeueConnectionForUse()
+        // When
+        let connection = try pool.dequeueConnectionForUse()
 
-            // Then
-            XCTAssertFalse(pool.availableConnections.contains(connection), "available connections should not contain connection")
-            XCTAssertTrue(pool.busyConnections.contains(connection), "busy connections should contain connection")
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertFalse(pool.availableConnections.contains(connection))
+        XCTAssertTrue(pool.busyConnections.contains(connection))
     }
 
-    func testThatDequeueingConnectionCreatesNewConnectionAndExecutesPreparationClosure() {
-        do {
-            // Given
-            let pool = ConnectionPool(
-                storageLocation: storageLocation,
-                connectionPreparation: { connection in
-                    try connection.execute("PRAGMA synchronous = 1")
-                }
-            )
-
-            pool.availableConnections.removeAll()
-
-            var synchronous: Int?
-
-            // When
-            let connection = try pool.dequeueConnectionForUse()
-
-            try pool.execute { connection in
-                synchronous = try connection.query("PRAGMA synchronous")
+    func testThatDequeueingConnectionCreatesNewConnectionAndExecutesPreparationClosure() throws {
+        // Given
+        let pool = ConnectionPool(
+            storageLocation: storageLocation,
+            connectionPreparation: { connection in
+                try connection.execute("PRAGMA synchronous = 1")
             }
+        )
 
-            // Then
-            XCTAssertFalse(pool.availableConnections.contains(connection))
-            XCTAssertTrue(pool.busyConnections.contains(connection))
-            XCTAssertEqual(synchronous, 1)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+        pool.availableConnections.removeAll()
+
+        var synchronous: Int?
+
+        // When
+        let connection = try pool.dequeueConnectionForUse()
+
+        try pool.execute { connection in
+            synchronous = try connection.query("PRAGMA synchronous")
         }
+
+        // Then
+        XCTAssertFalse(pool.availableConnections.contains(connection))
+        XCTAssertTrue(pool.busyConnections.contains(connection))
+        XCTAssertEqual(synchronous, 1)
     }
 
-    func testThatEnqueueConnectionRemovesBusyConnectionAndInsertsAvailableConnection() {
-        do {
-            // Given
-            let pool = ConnectionPool(storageLocation: storageLocation)
-            let connection = try pool.dequeueConnectionForUse()
+    func testThatEnqueueConnectionRemovesBusyConnectionAndInsertsAvailableConnection() throws {
+        // Given
+        let pool = ConnectionPool(storageLocation: storageLocation)
+        let connection = try pool.dequeueConnectionForUse()
 
-            let beforeEnqueueAvailableConnections = pool.availableConnections
-            let beforeEnqueueBusyConnections = pool.busyConnections
+        let beforeEnqueueAvailableConnections = pool.availableConnections
+        let beforeEnqueueBusyConnections = pool.busyConnections
 
-            // When
-            pool.enqueueConnectionForReuse(connection)
+        // When
+        pool.enqueueConnectionForReuse(connection)
 
-            // Then
-            XCTAssertFalse(beforeEnqueueAvailableConnections.contains(connection), "available connections should not contain connection before enqueue")
-            XCTAssertTrue(beforeEnqueueBusyConnections.contains(connection), "busy connections should contain connection before enqueue")
+        // Then
+        XCTAssertFalse(beforeEnqueueAvailableConnections.contains(connection))
+        XCTAssertTrue(beforeEnqueueBusyConnections.contains(connection))
 
-            XCTAssertTrue(pool.availableConnections.contains(connection), "available connections should contain connection after enqueue")
-            XCTAssertFalse(pool.busyConnections.contains(connection), "busy connections should not contain connection after enqueue")
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        XCTAssertTrue(pool.availableConnections.contains(connection))
+        XCTAssertFalse(pool.busyConnections.contains(connection))
     }
 
-    func testThatConnectionPoolCanExecuteReadOnlyClosure() {
-        do {
-            // Given
-            let pool = ConnectionPool(storageLocation: storageLocation)
+    func testThatConnectionPoolCanExecuteReadOnlyClosure() throws {
+        // Given
+        let pool = ConnectionPool(storageLocation: storageLocation)
 
-            var count: Int?
+        var count: Int?
 
-            // When
-            try pool.execute { connection in
-                count = try connection.query("SELECT count(*) FROM sqlite_master where type = 'table'")
-            }
-
-            // Then
-            XCTAssertEqual(count, 0)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+        // When
+        try pool.execute { connection in
+            count = try connection.query("SELECT count(*) FROM sqlite_master where type = 'table'")
         }
+
+        // Then
+        XCTAssertEqual(count, 0)
     }
 
     func testThatConnectionPoolFailsToExecuteWriteClosure() {
@@ -150,99 +134,91 @@ class ConnectionPoolTestCase: BaseTestCase {
             XCTFail("Execution should not reach this point")
         } catch let error as SQLiteError {
             // Then
-            XCTAssertEqual(error.code, SQLITE_READONLY, "error code should equal SQLITE_READONLY")
+            XCTAssertEqual(error.code, SQLITE_READONLY)
         } catch {
             XCTFail("Failed with an unknown error type: \(error)")
         }
     }
 
-    func testThatConnectionPoolCanExecuteMultipleClosuresInParallel() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            try TestTables.createAndPopulateAgentsTable(using: connection)
-            let pool = ConnectionPool(storageLocation: storageLocation)
+    func testThatConnectionPoolCanExecuteMultipleClosuresInParallel() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        try TestTables.createAndPopulateAgentsTable(using: connection)
+        let pool = ConnectionPool(storageLocation: storageLocation)
 
-            let range = 0..<128
-            let expectations: [XCTestExpectation] = range.map { expectation(description: "read: \($0)") }
-            var counts: [Int] = []
+        let range = 0..<128
+        let expectations: [XCTestExpectation] = range.map { expectation(description: "read: \($0)") }
+        var counts: [Int] = []
 
-            let queue = DispatchQueue(label: "test_serial_queue")
-            let utilityQueue = DispatchQueue.global(qos: .utility)
+        let queue = DispatchQueue(label: "test_serial_queue")
+        let utilityQueue = DispatchQueue.global(qos: .utility)
 
-            // When
-            range.forEach { index in
-                utilityQueue.async {
-                    do {
-                        try pool.execute { connection in
-                            guard let count: Int = try connection.query("SELECT count(*) FROM agents") else { return }
-                            queue.sync { counts.append(count) }
-                        }
-                    } catch {
-                        // No-op
+        // When
+        range.forEach { index in
+            utilityQueue.async {
+                do {
+                    try pool.execute { connection in
+                        guard let count: Int = try connection.query("SELECT count(*) FROM agents") else { return }
+                        queue.sync { counts.append(count) }
                     }
-
-                    expectations[index].fulfill()
+                } catch {
+                    // No-op
                 }
+
+                expectations[index].fulfill()
             }
+        }
 
-            waitForExpectations(timeout: 10.0, handler: nil)
+        waitForExpectations(timeout: 10.0, handler: nil)
 
-            // Then
-            XCTAssertEqual(counts.count, range.count)
+        // Then
+        XCTAssertEqual(counts.count, range.count)
 
-            for count in counts {
-                XCTAssertEqual(count, 2)
-            }
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+        for count in counts {
+            XCTAssertEqual(count, 2)
         }
     }
 
-    func testThatConnectionPoolDrainDelayWorksAsExpected() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            try TestTables.createAndPopulateAgentsTable(using: connection)
-            let pool = ConnectionPool(storageLocation: storageLocation, availableConnectionDrainDelay: 0.1)
+    func testThatConnectionPoolDrainDelayWorksAsExpected() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        try TestTables.createAndPopulateAgentsTable(using: connection)
+        let pool = ConnectionPool(storageLocation: storageLocation, availableConnectionDrainDelay: 0.1)
 
-            let range = 0..<10
-            let expectations: [XCTestExpectation] = range.map { expectation(description: "read: \($0)") }
-            var counts: [Int] = []
+        let range = 0..<10
+        let expectations: [XCTestExpectation] = range.map { expectation(description: "read: \($0)") }
+        var counts: [Int] = []
 
-            let queue = DispatchQueue(label: "test_serial_queue")
-            let utilityQueue = DispatchQueue.global(qos: .utility)
+        let queue = DispatchQueue(label: "test_serial_queue")
+        let utilityQueue = DispatchQueue.global(qos: .utility)
 
-            // When
-            range.forEach { index in
-                utilityQueue.async {
-                    do {
-                        try pool.execute { connection in
-                            guard let count: Int = try connection.query("SELECT count(*) FROM agents") else { return }
-                            queue.sync { counts.append(count) }
-                        }
-                    } catch {
-                        // No-op
+        // When
+        range.forEach { index in
+            utilityQueue.async {
+                do {
+                    try pool.execute { connection in
+                        guard let count: Int = try connection.query("SELECT count(*) FROM agents") else { return }
+                        queue.sync { counts.append(count) }
                     }
-
-                    expectations[index].fulfill()
+                } catch {
+                    // No-op
                 }
+
+                expectations[index].fulfill()
             }
+        }
 
-            let drainExpectation = expectation(description: "drain timer should drain available connections")
-            DispatchQueue.main.asyncAfter(seconds: 0.2) { drainExpectation.fulfill() }
+        let drainExpectation = expectation(description: "drain timer should drain available connections")
+        DispatchQueue.main.asyncAfter(seconds: 0.2) { drainExpectation.fulfill() }
 
-            waitForExpectations(timeout: 10.0, handler: nil)
+        waitForExpectations(timeout: 10.0, handler: nil)
 
-            // Then
-            XCTAssertEqual(pool.availableConnections.count, 1, "available connections count should be back down to 1")
-            XCTAssertEqual(counts.count, range.count, "counts array should have equal number of items as range")
+        // Then
+        XCTAssertEqual(pool.availableConnections.count, 1, "available connections count should be back down to 1")
+        XCTAssertEqual(counts.count, range.count, "counts array should have equal number of items as range")
 
-            for (index, count) in counts.enumerated() {
-                XCTAssertEqual(count, 2, "count should be equal to 2 at index: \(index)")
-            }
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+        for (index, count) in counts.enumerated() {
+            XCTAssertEqual(count, 2, "count should be equal to 2 at index: \(index)")
         }
     }
 }

--- a/Tests/Tests/Connection/ConnectionQueueTests.swift
+++ b/Tests/Tests/Connection/ConnectionQueueTests.swift
@@ -14,28 +14,24 @@ import SQLite3
 import XCTest
 
 class ConnectionQueueTestCase: BaseTestCase {
-    func testThatConnectionQueueCanExecuteStatements() {
-        do {
-            // Given
-            let queue = try ConnectionQueue(connection: Connection(storageLocation: storageLocation))
+    func testThatConnectionQueueCanExecuteStatements() throws {
+        // Given
+        let queue = try ConnectionQueue(connection: Connection(storageLocation: storageLocation))
 
-            var rowCount: Int64?
+        var rowCount: Int64?
 
-            // When, Then
-            try queue.execute { connection in
-                try connection.execute("DROP TABLE IF EXISTS agents")
-                try connection.execute("CREATE TABLE agents(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, job TEXT)")
-                try connection.run("INSERT INTO agents(name, job) VALUES(?, ?)", "Sterling Archer", "World's Greatest Secret Agent")
-                try connection.run("INSERT INTO agents(name, job) VALUES(?, ?)", "Lana Kane", "Top Agent")
+        // When, Then
+        try queue.execute { connection in
+            try connection.execute("DROP TABLE IF EXISTS agents")
+            try connection.execute("CREATE TABLE agents(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, job TEXT)")
+            try connection.run("INSERT INTO agents(name, job) VALUES(?, ?)", "Sterling Archer", "World's Greatest Secret Agent")
+            try connection.run("INSERT INTO agents(name, job) VALUES(?, ?)", "Lana Kane", "Top Agent")
 
-                rowCount = try connection.query("SELECT count(*) FROM agents")
-            }
-
-            // Then
-            XCTAssertEqual(rowCount, 2)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+            rowCount = try connection.query("SELECT count(*) FROM agents")
         }
+
+        // Then
+        XCTAssertEqual(rowCount, 2)
     }
 
     func testThatConnectionQueueThrowsErrorWhenExecutingStatement() {
@@ -51,34 +47,30 @@ class ConnectionQueueTestCase: BaseTestCase {
             XCTFail("Execution should not reach this point")
         } catch let error as SQLiteError {
             // Then
-            XCTAssertEqual(error.code, SQLITE_ERROR, "error code should be equal to `SQLITE_ERROR`")
+            XCTAssertEqual(error.code, SQLITE_ERROR)
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
     }
 
-    func testThatConnectionQueueCanExecuteStatementsInTransaction() {
-        do {
-            // Given
-            let queue = try ConnectionQueue(connection: Connection(storageLocation: storageLocation))
+    func testThatConnectionQueueCanExecuteStatementsInTransaction() throws {
+        // Given
+        let queue = try ConnectionQueue(connection: Connection(storageLocation: storageLocation))
 
-            var rowCount: Int64?
+        var rowCount: Int64?
 
-            // When, Then
-            try queue.executeInTransaction { connection in
-                try connection.execute("DROP TABLE IF EXISTS agents")
-                try connection.execute("CREATE TABLE agents(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, job TEXT)")
-                try connection.run("INSERT INTO agents(name, job) VALUES(?, ?)", "Sterling Archer", "World's Greatest Secret Agent")
-                try connection.run("INSERT INTO agents(name, job) VALUES(?, ?)", "Lana Kane", "Top Agent")
+        // When, Then
+        try queue.executeInTransaction { connection in
+            try connection.execute("DROP TABLE IF EXISTS agents")
+            try connection.execute("CREATE TABLE agents(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, job TEXT)")
+            try connection.run("INSERT INTO agents(name, job) VALUES(?, ?)", "Sterling Archer", "World's Greatest Secret Agent")
+            try connection.run("INSERT INTO agents(name, job) VALUES(?, ?)", "Lana Kane", "Top Agent")
 
-                rowCount = try connection.query("SELECT count(*) FROM agents")
-            }
-
-            // Then
-            XCTAssertEqual(rowCount, 2)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+            rowCount = try connection.query("SELECT count(*) FROM agents")
         }
+
+        // Then
+        XCTAssertEqual(rowCount, 2)
     }
 
     func testThatConnectionQueueThrowsErrorWhenExecutingTransaction() {
@@ -94,34 +86,30 @@ class ConnectionQueueTestCase: BaseTestCase {
             XCTFail("Execution should not reach this point")
         } catch let error as SQLiteError {
             // Then
-            XCTAssertEqual(error.code, SQLITE_ERROR, "error code should be equal to `SQLITE_ERROR`")
+            XCTAssertEqual(error.code, SQLITE_ERROR)
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }
     }
 
-    func testThatConnectionQueueCanExecuteStatementsInSavepoint() {
-        do {
-            // Given
-            let queue = try ConnectionQueue(connection: Connection(storageLocation: storageLocation))
+    func testThatConnectionQueueCanExecuteStatementsInSavepoint() throws {
+        // Given
+        let queue = try ConnectionQueue(connection: Connection(storageLocation: storageLocation))
 
-            var rowCount: Int64?
+        var rowCount: Int64?
 
-            // When, Then
-            try queue.executeInSavepoint(named: "savepoint name with spaces") { connection in
-                try connection.execute("DROP TABLE IF EXISTS agents")
-                try connection.execute("CREATE TABLE agents(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, job TEXT)")
-                try connection.run("INSERT INTO agents(name, job) VALUES(?, ?)", "Sterling Archer", "World's Greatest Secret Agent")
-                try connection.run("INSERT INTO agents(name, job) VALUES(?, ?)", "Lana Kane", "Top Agent")
+        // When, Then
+        try queue.executeInSavepoint(named: "savepoint name with spaces") { connection in
+            try connection.execute("DROP TABLE IF EXISTS agents")
+            try connection.execute("CREATE TABLE agents(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT, job TEXT)")
+            try connection.run("INSERT INTO agents(name, job) VALUES(?, ?)", "Sterling Archer", "World's Greatest Secret Agent")
+            try connection.run("INSERT INTO agents(name, job) VALUES(?, ?)", "Lana Kane", "Top Agent")
 
-                rowCount = try connection.query("SELECT count(*) FROM agents")
-            }
-
-            // Then
-            XCTAssertEqual(rowCount, 2)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+            rowCount = try connection.query("SELECT count(*) FROM agents")
         }
+
+        // Then
+        XCTAssertEqual(rowCount, 2)
     }
 
     func testThatConnectionQueueThrowsErrorWhenExecutingSavepoint() {
@@ -137,7 +125,7 @@ class ConnectionQueueTestCase: BaseTestCase {
             XCTFail("Execution should not reach this point")
         } catch let error as SQLiteError {
             // Then
-            XCTAssertEqual(error.code, SQLITE_ERROR, "error code should be equal to `SQLITE_ERROR`")
+            XCTAssertEqual(error.code, SQLITE_ERROR)
         } catch {
             XCTFail("Test encountered unexpected error: \(error)")
         }

--- a/Tests/Tests/Connection/ConnectionTests.swift
+++ b/Tests/Tests/Connection/ConnectionTests.swift
@@ -17,320 +17,264 @@ class ConnectionTestCase: BaseTestCase {
 
     // MARK: - Tests - Open and Close Connection
 
-    func testThatConnectionCanOpenDatabaseConnection() {
+    func testThatConnectionCanOpenDatabaseConnection() throws {
         // Given, When, Then
-        do {
-            let _ = try Connection(storageLocation: storageLocation)
-            let _ = try Connection(storageLocation: .inMemory)
-            let _ = try Connection(storageLocation: .temporary)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        let _ = try Connection(storageLocation: storageLocation)
+        let _ = try Connection(storageLocation: .inMemory)
+        let _ = try Connection(storageLocation: .temporary)
     }
 
-    func testThatConnectionInitializationDefaultFlagsMatchConnectionPropertyValues() {
-        do {
-            // Given, When
-            let connection = try Connection(storageLocation: storageLocation)
+    func testThatConnectionInitializationDefaultFlagsMatchConnectionPropertyValues() throws {
+        // Given, When
+        let connection = try Connection(storageLocation: storageLocation)
 
-            // Then
-            XCTAssertFalse(connection.readOnly)
-            XCTAssertTrue(connection.threadSafe)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertFalse(connection.readOnly)
+        XCTAssertTrue(connection.threadSafe)
     }
 
-    func testThatConnectionInitializationCustomFlagsMatchConnectionPropertyValues() {
-        do {
-            // Given
-            var writableConnection: Connection? = try Connection(storageLocation: storageLocation)
-            try writableConnection?.execute("PRAGMA foreign_keys = true")
-            let writableForeignKeys: Bool = try writableConnection?.query("PRAGMA foreign_keys") ?? false
-            writableConnection = nil
+    func testThatConnectionInitializationCustomFlagsMatchConnectionPropertyValues() throws {
+        // Given
+        var writableConnection: Connection? = try Connection(storageLocation: storageLocation)
+        try writableConnection?.execute("PRAGMA foreign_keys = true")
+        let writableForeignKeys: Bool = try writableConnection?.query("PRAGMA foreign_keys") ?? false
+        writableConnection = nil
 
-            // When
-            let readOnlyConnection = try Connection(storageLocation: storageLocation, readOnly: true, multiThreaded: false)
-            let readOnlyForeignKeys: Bool? = try readOnlyConnection.query("PRAGMA foreign_keys")
+        // When
+        let readOnlyConnection = try Connection(storageLocation: storageLocation, readOnly: true, multiThreaded: false)
+        let readOnlyForeignKeys: Bool? = try readOnlyConnection.query("PRAGMA foreign_keys")
 
-            // Then
-            XCTAssertEqual(readOnlyConnection.readOnly, true)
-            XCTAssertEqual(readOnlyConnection.threadSafe, true)
-            XCTAssertEqual(writableForeignKeys, true)
-            XCTAssertEqual(readOnlyForeignKeys, false)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(readOnlyConnection.readOnly, true)
+        XCTAssertEqual(readOnlyConnection.threadSafe, true)
+        XCTAssertEqual(writableForeignKeys, true)
+        XCTAssertEqual(readOnlyForeignKeys, false)
     }
 
-    func testThatConnectionCanCloseDatabaseConnection() {
-        do {
-            // Given
-            var onDiskConnection: Connection? = try Connection(storageLocation: storageLocation)
-            var inMemoryConnection: Connection? = try Connection(storageLocation: .inMemory)
-            var temporaryConnection: Connection? = try Connection(storageLocation: .temporary)
+    func testThatConnectionCanCloseDatabaseConnection() throws {
+        // Given
+        var onDiskConnection: Connection? = try Connection(storageLocation: storageLocation)
+        var inMemoryConnection: Connection? = try Connection(storageLocation: .inMemory)
+        var temporaryConnection: Connection? = try Connection(storageLocation: .temporary)
 
-            // When, Then
-            try onDiskConnection?.execute("PRAGMA foreign_keys = true")
-            onDiskConnection = nil
+        // When, Then
+        try onDiskConnection?.execute("PRAGMA foreign_keys = true")
+        onDiskConnection = nil
 
-            try inMemoryConnection?.execute("PRAGMA foreign_keys = true")
-            inMemoryConnection = nil
+        try inMemoryConnection?.execute("PRAGMA foreign_keys = true")
+        inMemoryConnection = nil
 
-            try temporaryConnection?.execute("PRAGMA foreign_keys = true")
-            temporaryConnection = nil
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        try temporaryConnection?.execute("PRAGMA foreign_keys = true")
+        temporaryConnection = nil
     }
 
     // MARK: - Tests - Execution
 
-    func testThatConnectionCanExecutePragmaStatements() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
+    func testThatConnectionCanExecutePragmaStatements() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
 
-            // When, Then
-            try connection.execute("""
-                PRAGMA foreign_keys = true;
-                PRAGMA journal_mode = WAL
+        // When, Then
+        try connection.execute("""
+            PRAGMA foreign_keys = true;
+            PRAGMA journal_mode = WAL
+            """
+        )
+    }
+
+    func testThatConnectionCanCreateTable() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+
+        // When, Then
+        try connection.execute("CREATE TABLE cars(id INTEGER PRIMARY KEY, name TEXT, price INTEGER)")
+    }
+
+    func testThatConnectionCanDropTable() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+
+        // When, Then
+        try connection.execute("""
+            CREATE TABLE cars(id INTEGER PRIMARY KEY, name TEXT, price INTEGER);
+            DROP TABLE cars
+            """
+        )
+    }
+
+    func testThatConnectionCanInsertRowsIntoTable() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+
+        // When, Then
+        try connection.execute("""
+            CREATE TABLE cars(id INTEGER PRIMARY KEY, name TEXT, price INTEGER);
+            INSERT INTO cars VALUES(1, 'Audi', 52642);
+            INSERT INTO cars VALUES(2, 'Mercedes', 57127);
+            INSERT INTO cars VALUES(3, 'Skoda', 9000)
+            """
+        )
+    }
+
+    func testThatConnectionCanInsertThousandsOfRowsIntoTableUnderOneSecond() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        try connection.execute("PRAGMA synchronous = NORMAL")
+        try connection.execute("PRAGMA journal_mode = WAL")
+        try TestTables.createAndPopulateAgentsTable(using: connection)
+
+        // NOTE: Most machines can insert ~25_000 rows per second with these settings. May need to decrease the
+        // number of rows on CI machines due to running inside a VM.
+
+        // When
+        let start = Date()
+
+        try connection.transaction {
+            let jobTitle = "Superman".data(using: .utf8)!
+            let insert = try connection.prepare("""
+                INSERT INTO agents(name, date, missions, salary, job_title, car) VALUES(?, ?, ?, ?, ?, ?)
                 """
             )
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
-    }
 
-    func testThatConnectionCanCreateTable() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-
-            // When, Then
-            try connection.execute("CREATE TABLE cars(id INTEGER PRIMARY KEY, name TEXT, price INTEGER)")
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
-    }
-
-    func testThatConnectionCanDropTable() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-
-            // When, Then
-            try connection.execute("""
-                CREATE TABLE cars(id INTEGER PRIMARY KEY, name TEXT, price INTEGER);
-                DROP TABLE cars
-                """
-            )
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
-    }
-
-    func testThatConnectionCanInsertRowsIntoTable() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-
-            // When, Then
-            try connection.execute("""
-                CREATE TABLE cars(id INTEGER PRIMARY KEY, name TEXT, price INTEGER);
-                INSERT INTO cars VALUES(1, 'Audi', 52642);
-                INSERT INTO cars VALUES(2, 'Mercedes', 57127);
-                INSERT INTO cars VALUES(3, 'Skoda', 9000)
-                """
-            )
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
-    }
-
-    func testThatConnectionCanInsertThousandsOfRowsIntoTableUnderOneSecond() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            try connection.execute("PRAGMA synchronous = NORMAL")
-            try connection.execute("PRAGMA journal_mode = WAL")
-            try TestTables.createAndPopulateAgentsTable(using: connection)
-
-            // NOTE: Most machines can insert ~25_000 rows per second with these settings. May need to decrease the
-            // number of rows on CI machines due to running inside a VM.
-
-            // When
-            let start = Date()
-
-            try connection.transaction {
-                let jobTitle = "Superman".data(using: .utf8)!
-                let insert = try connection.prepare("""
-                    INSERT INTO agents(name, date, missions, salary, job_title, car) VALUES(?, ?, ?, ?, ?, ?)
-                    """
-                )
-
-                for index in 1...20_000 {
-                    try insert.bind("Sterling Archer-\(index)", "2015-10-02T08:20:00.000", 485, 240_000.10, jobTitle, "Charger").run()
-                }
+            for index in 1...20_000 {
+                try insert.bind("Sterling Archer-\(index)", "2015-10-02T08:20:00.000", 485, 240_000.10, jobTitle, "Charger").run()
             }
-
-            let timeInterval = start.timeIntervalSinceNow
-
-            // Then
-            XCTAssertLessThan(timeInterval, 1.000, "database should be able to insert 25_000 rows in under 1 second")
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
         }
+
+        let timeInterval = start.timeIntervalSinceNow
+
+        // Then
+        XCTAssertLessThan(timeInterval, 1.000, "database should be able to insert 25_000 rows in under 1 second")
     }
 
-    func testThatConnectionCanUpdateRowsInTable() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
+    func testThatConnectionCanUpdateRowsInTable() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
 
-            // When, Then
-            try connection.execute("""
-                CREATE TABLE cars(id INTEGER PRIMARY KEY, name TEXT, price INTEGER);
-                INSERT INTO cars VALUES(1, 'Audi', 52642);
-                UPDATE cars SET price = 89400 WHERE id = 1
-                """
-            )
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // When, Then
+        try connection.execute("""
+            CREATE TABLE cars(id INTEGER PRIMARY KEY, name TEXT, price INTEGER);
+            INSERT INTO cars VALUES(1, 'Audi', 52642);
+            UPDATE cars SET price = 89400 WHERE id = 1
+            """
+        )
     }
 
-    func testThatConnectionCanDeleteRowsInTable() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
+    func testThatConnectionCanDeleteRowsInTable() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
 
-            // When
-            try connection.execute("""
-                CREATE TABLE cars(id INTEGER PRIMARY KEY, name TEXT, price INTEGER);
-                INSERT INTO cars VALUES(1, 'Audi', 52642);
-                DELETE FROM cars
-                """
-            )
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // When
+        try connection.execute("""
+            CREATE TABLE cars(id INTEGER PRIMARY KEY, name TEXT, price INTEGER);
+            INSERT INTO cars VALUES(1, 'Audi', 52642);
+            DELETE FROM cars
+            """
+        )
     }
 
     // MARK: - Tests - Interrupt
 
-    func testThatConnectionCanInterruptLongRunningOperation() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            try connection.execute("CREATE TABLE cars(id INTEGER PRIMARY KEY, name TEXT, price INTEGER)")
+    func testThatConnectionCanInterruptLongRunningOperation() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        try connection.execute("CREATE TABLE cars(id INTEGER PRIMARY KEY, name TEXT, price INTEGER)")
 
-            try connection.transaction {
-                let statement = try connection.prepare("INSERT INTO cars(name, price) VALUES(?, ?)")
-                try (1...10_000).forEach { try statement.bind("BMW", $0).run() }
+        try connection.transaction {
+            let statement = try connection.prepare("INSERT INTO cars(name, price) VALUES(?, ?)")
+            try (1...10_000).forEach { try statement.bind("BMW", $0).run() }
+        }
+
+        let expectation = self.expectation(description: "transaction should be cancelled")
+        var prices: [Int]?
+        var queryError: Error?
+
+        // When
+        DispatchQueue.utility.async {
+            do {
+                prices = try connection.query("SELECT price FROM cars")
+                expectation.fulfill()
+            } catch {
+                queryError = error
+                expectation.fulfill()
             }
+        }
 
-            let expectation = self.expectation(description: "transaction should be cancelled")
-            var prices: [Int]?
-            var queryError: Error?
+        DispatchQueue.utility.asyncAfter(seconds: 0.005) { connection.interrupt() }
+        waitForExpectations(timeout: 5, handler: nil)
 
-            // When
-            DispatchQueue.utility.async {
-                do {
-                    prices = try connection.query("SELECT price FROM cars")
-                    expectation.fulfill()
-                } catch {
-                    queryError = error
-                    expectation.fulfill()
-                }
+        // Then (sometimes interrupt won't stop the query prior to completion)
+        if let prices = prices {
+            XCTAssertNil(queryError)
+            XCTAssertEqual(prices.count, 10_000)
+        } else {
+            XCTAssertNil(prices)
+            XCTAssertNotNil(queryError)
+
+            if let error = queryError as? SQLiteError {
+                XCTAssertEqual(error.code, SQLITE_INTERRUPT)
+                XCTAssertEqual(error.message, "interrupted")
             }
-
-            DispatchQueue.utility.asyncAfter(seconds: 0.005) { connection.interrupt() }
-            waitForExpectations(timeout: 5, handler: nil)
-
-            // Then (sometimes interrupt won't stop the query prior to completion)
-            if let prices = prices {
-                XCTAssertNil(queryError)
-                XCTAssertEqual(prices.count, 10_000)
-            } else {
-                XCTAssertNil(prices)
-                XCTAssertNotNil(queryError)
-
-                if let error = queryError as? SQLiteError {
-                    XCTAssertEqual(error.code, SQLITE_INTERRUPT)
-                    XCTAssertEqual(error.message, "interrupted")
-                }
-            }
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
         }
     }
 
     // MARK: - Tests - FTS4
 
-    func testThatConnectionSupportsFTS4Module() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
+    func testThatConnectionSupportsFTS4Module() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
 
-            try connection.execute("""
-                CREATE VIRTUAL TABLE email USING fts4(sender, title, body);
-                INSERT INTO email VALUES('Christian Noon', 'iOS Architectures', 'There are so many possibilities');
-                INSERT INTO email VALUES('Dave Camp', 'SQift Features', 'Should we support so many SQLite APIs?')
-                """
-            )
+        try connection.execute("""
+            CREATE VIRTUAL TABLE email USING fts4(sender, title, body);
+            INSERT INTO email VALUES('Christian Noon', 'iOS Architectures', 'There are so many possibilities');
+            INSERT INTO email VALUES('Dave Camp', 'SQift Features', 'Should we support so many SQLite APIs?')
+            """
+        )
 
-            // When
-            let emailRowCount: Int? = try connection.query("SELECT count(1) FROM email")
-            let senders1: [String] = try connection.query("SELECT sender FROM email WHERE email MATCH 'many'")
-            let senders2: [String] = try connection.query("SELECT sender FROM email WHERE body MATCH 'so NOT support'")
+        // When
+        let emailRowCount: Int? = try connection.query("SELECT count(1) FROM email")
+        let senders1: [String] = try connection.query("SELECT sender FROM email WHERE email MATCH 'many'")
+        let senders2: [String] = try connection.query("SELECT sender FROM email WHERE body MATCH 'so NOT support'")
 
-            // Then
-            XCTAssertEqual(emailRowCount, 2)
-            XCTAssertEqual(senders1, ["Christian Noon", "Dave Camp"])
-            XCTAssertEqual(senders2, ["Christian Noon"])
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(emailRowCount, 2)
+        XCTAssertEqual(senders1, ["Christian Noon", "Dave Camp"])
+        XCTAssertEqual(senders2, ["Christian Noon"])
     }
 
     // MARK: - Tests - Attach Database
 
-    func testThatConnectionCanAttachAndDetachDatabase() {
+    func testThatConnectionCanAttachAndDetachDatabase() throws {
         let personDBPath = FileManager.cachesDirectory.appending("/attach_detach_db_tests.db")
         defer { FileManager.removeItem(atPath: personDBPath) }
 
-        do {
-            // Given
-            let connection1 = try Connection(storageLocation: storageLocation)
-            try connection1.execute("CREATE TABLE cars(id INTEGER PRIMARY KEY, name TEXT, price INTEGER)")
-            try connection1.prepare("INSERT INTO cars VALUES(?, ?, ?)").bind(1, "Audi", 52642).run()
+        // Given
+        let connection1 = try Connection(storageLocation: storageLocation)
+        try connection1.execute("CREATE TABLE cars(id INTEGER PRIMARY KEY, name TEXT, price INTEGER)")
+        try connection1.prepare("INSERT INTO cars VALUES(?, ?, ?)").bind(1, "Audi", 52642).run()
 
-            var connection2: Connection? = try Connection(storageLocation: .onDisk(personDBPath))
-            try connection2?.execute("CREATE TABLE person(id INTEGER PRIMARY KEY, name TEXT)")
-            try connection2?.prepare("INSERT INTO person VALUES(?, ?)").bind(1, "Sterling Archer").run()
+        var connection2: Connection? = try Connection(storageLocation: .onDisk(personDBPath))
+        try connection2?.execute("CREATE TABLE person(id INTEGER PRIMARY KEY, name TEXT)")
+        try connection2?.prepare("INSERT INTO person VALUES(?, ?)").bind(1, "Sterling Archer").run()
 
-            connection2 = nil
+        connection2 = nil
 
-            // When
-            try connection1.attachDatabase(from: StorageLocation.onDisk(personDBPath), withName: "personDB")
-            try connection1.prepare("INSERT INTO person VALUES(?, ?)").bind(2, "Lana Kane").run()
-            let rows: [[Any?]] = try connection1.query("SELECT * FROM person") { $0.values }
+        // When
+        try connection1.attachDatabase(from: StorageLocation.onDisk(personDBPath), withName: "personDB")
+        try connection1.prepare("INSERT INTO person VALUES(?, ?)").bind(2, "Lana Kane").run()
+        let rows: [[Any?]] = try connection1.query("SELECT * FROM person") { $0.values }
 
-            try connection1.detachDatabase(named: "personDB")
+        try connection1.detachDatabase(named: "personDB")
 
-            // Then
-            if rows.count == 2 {
-                XCTAssertEqual(rows[0][0] as? Int64, 1, "rows[0][0] should be 1")
-                XCTAssertEqual(rows[0][1] as? String, "Sterling Archer", "rows[0][1] should be `Sterling Archer`")
+        // Then
+        if rows.count == 2 {
+            XCTAssertEqual(rows[0][0] as? Int64, 1)
+            XCTAssertEqual(rows[0][1] as? String, "Sterling Archer")
 
-                XCTAssertEqual(rows[1][0] as? Int64, 2, "rows[1][0] should be 2")
-                XCTAssertEqual(rows[1][1] as? String, "Lana Kane", "rows[1][1] should be `Lana Kane`")
-            } else {
-                XCTFail("rows count should be 2")
-            }
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+            XCTAssertEqual(rows[1][0] as? Int64, 2)
+            XCTAssertEqual(rows[1][1] as? String, "Lana Kane")
+        } else {
+            XCTFail("rows count should be 2")
         }
     }
 }

--- a/Tests/Tests/Connection/Functions/BusyTests.swift
+++ b/Tests/Tests/Connection/Functions/BusyTests.swift
@@ -29,175 +29,163 @@ class BusyTestCase: BaseConnectionTestCase {
 
     // MARK: - Tests
 
-    func testThatConnectionCanSetTimeoutBusyHandler() {
-        do {
-            // Given
-            try TestTables.insertDummyAgents(count: 1_000, connection: connection)
+    func testThatConnectionCanSetTimeoutBusyHandler() throws {
+        // Given
+        try TestTables.insertDummyAgents(count: 1_000, connection: connection)
 
-            let readConnection = try Connection(storageLocation: storageLocation, readOnly: true)
+        let readConnection = try Connection(storageLocation: storageLocation, readOnly: true)
 
-            let readExpectation = self.expectation(description: "agents should be retrieved from database")
-            let checkpointExpectation = self.expectation(description: "checkpoint operation should succeed")
+        let readExpectation = self.expectation(description: "agents should be retrieved from database")
+        let checkpointExpectation = self.expectation(description: "checkpoint operation should succeed")
 
-            var agents: [Agent]?
-            var checkpointError: Error?
+        var agents: [Agent]?
+        var checkpointError: Error?
 
-            // When
-            let timeout: TimeInterval
+        // When
+        let timeout: TimeInterval
 
-            // CN (8/21/17) - I can't find a way around this issue. It seems that iOS 10 and 11 might have a
-            // simulator bug or potentially a bug in SQLite where the timeout is actually in nanoseconds instead
-            // of milliseconds. By bumping the value up, the tests do pass. Because of this, I'd strongly advocate
-            // that people only ever use custom busy handlers that track their own timing rather than using the
-            // timeout busy handler. Again, this may only be an issue in the unit tests and the simulator.
-            //
-            // I also tested using `PRAGMA busy_timeout = 2000` and the same behavior is observed. I can't find
-            // any information about this online which is odd, but we should really avoid using this in production.
-            if #available(iOS 10.0, macOS 10.12, tvOS 10.0, *) {
-                timeout = 20_000.0
-                // try connection.execute("PRAGMA busy_timeout = 2000")
-            } else {
-                timeout = 2.0
-            }
-
-            try connection.busyHandler(.timeout(timeout)) // throws SQLITE_BUSY error if this is disabled
-
-            DispatchQueue.utility.async {
-                do {
-                    agents = try readConnection.query("SELECT * FROM agents")
-                    readExpectation.fulfill()
-                } catch {
-                    // No-op
-                }
-            }
-
-            DispatchQueue.utility.asyncAfter(seconds: 0.01) {
-                do {
-                    _ = try self.connection.checkpoint(mode: .truncate)
-                    checkpointExpectation.fulfill()
-                } catch {
-                    checkpointError = error
-                    checkpointExpectation.fulfill()
-                }
-            }
-
-            waitForExpectations(timeout: timeout, handler: nil)
-
-            // Then
-            XCTAssertEqual(agents?.count, 1_002)
-            XCTAssertNil(checkpointError)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+        // CN (8/21/17) - I can't find a way around this issue. It seems that iOS 10 and 11 might have a
+        // simulator bug or potentially a bug in SQLite where the timeout is actually in nanoseconds instead
+        // of milliseconds. By bumping the value up, the tests do pass. Because of this, I'd strongly advocate
+        // that people only ever use custom busy handlers that track their own timing rather than using the
+        // timeout busy handler. Again, this may only be an issue in the unit tests and the simulator.
+        //
+        // I also tested using `PRAGMA busy_timeout = 2000` and the same behavior is observed. I can't find
+        // any information about this online which is odd, but we should really avoid using this in production.
+        if #available(iOS 10.0, macOS 10.12, tvOS 10.0, *) {
+            timeout = 20_000.0
+            // try connection.execute("PRAGMA busy_timeout = 2000")
+        } else {
+            timeout = 2.0
         }
+
+        try connection.busyHandler(.timeout(timeout)) // throws SQLITE_BUSY error if this is disabled
+
+        DispatchQueue.utility.async {
+            do {
+                agents = try readConnection.query("SELECT * FROM agents")
+                readExpectation.fulfill()
+            } catch {
+                // No-op
+            }
+        }
+
+        DispatchQueue.utility.asyncAfter(seconds: 0.01) {
+            do {
+                _ = try self.connection.checkpoint(mode: .truncate)
+                checkpointExpectation.fulfill()
+            } catch {
+                checkpointError = error
+                checkpointExpectation.fulfill()
+            }
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertEqual(agents?.count, 1_002)
+        XCTAssertNil(checkpointError)
     }
 
-    func testThatConnectionCanSetCustomBusyHandler() {
-        do {
-            // Given
-            try TestTables.insertDummyAgents(count: 10_000, connection: connection)
+    func testThatConnectionCanSetCustomBusyHandler() throws {
+        // Given
+        try TestTables.insertDummyAgents(count: 10_000, connection: connection)
 
-            let readConnection = try Connection(storageLocation: storageLocation, readOnly: true)
+        let readConnection = try Connection(storageLocation: storageLocation, readOnly: true)
 
-            let expectation = self.expectation(description: "agents should be retrieved from database")
-            var agents: [Agent]?
-            var checkpointError: Error?
+        let expectation = self.expectation(description: "agents should be retrieved from database")
+        var agents: [Agent]?
+        var checkpointError: Error?
 
-            let _busyInvocationLock = NSLock()
-            var _busyInvocationCount: Int32 = 0
+        let _busyInvocationLock = NSLock()
+        var _busyInvocationCount: Int32 = 0
 
-            var busyInvocationCount: Int32 {
-                get {
-                    _busyInvocationLock.lock() ; defer { _busyInvocationLock.unlock() }
-                    return _busyInvocationCount
-                }
-                set {
-                    _busyInvocationLock.lock() ; defer { _busyInvocationLock.unlock() }
-                    _busyInvocationCount = newValue
-                }
+        var busyInvocationCount: Int32 {
+            get {
+                _busyInvocationLock.lock() ; defer { _busyInvocationLock.unlock() }
+                return _busyInvocationCount
             }
-
-            // When
-            try connection.busyHandler(
-                .custom { attempts in
-                    busyInvocationCount = attempts + 1
-                    return true
-                }
-            )
-
-            DispatchQueue.utility.async {
-                do {
-                    agents = try readConnection.query("SELECT * FROM agents")
-                    expectation.fulfill()
-                } catch {
-                    // No-op
-                }
+            set {
+                _busyInvocationLock.lock() ; defer { _busyInvocationLock.unlock() }
+                _busyInvocationCount = newValue
             }
-
-            DispatchQueue.utility.asyncAfter(seconds: 0.01) {
-                do {
-                    _ = try self.connection.checkpoint(mode: .truncate)
-                } catch {
-                    checkpointError = error
-                }
-            }
-
-            waitForExpectations(timeout: timeout, handler: nil)
-
-            // Then
-            XCTAssertEqual(agents?.count, 10_002)
-            XCTAssertNil(checkpointError)
-            XCTAssertGreaterThan(busyInvocationCount, 0)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
         }
+
+        // When
+        try connection.busyHandler(
+            .custom { attempts in
+                busyInvocationCount = attempts + 1
+                return true
+            }
+        )
+
+        DispatchQueue.utility.async {
+            do {
+                agents = try readConnection.query("SELECT * FROM agents")
+                expectation.fulfill()
+            } catch {
+                // No-op
+            }
+        }
+
+        DispatchQueue.utility.asyncAfter(seconds: 0.01) {
+            do {
+                _ = try self.connection.checkpoint(mode: .truncate)
+            } catch {
+                checkpointError = error
+            }
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertEqual(agents?.count, 10_002)
+        XCTAssertNil(checkpointError)
+        XCTAssertGreaterThan(busyInvocationCount, 0)
     }
 
-    func testThatConnectionCanSetDefaultBehaviorBusyHandler() {
+    func testThatConnectionCanSetDefaultBehaviorBusyHandler() throws {
         // Disable test on CI since timing is too unpredictable
         guard !ProcessInfo.isRunningOnCI else { return }
 
-        do {
-            // Given
-            try TestTables.insertDummyAgents(count: 10_000, connection: connection)
+        // Given
+        try TestTables.insertDummyAgents(count: 10_000, connection: connection)
 
-            let readConnection = try Connection(storageLocation: storageLocation, readOnly: true)
+        let readConnection = try Connection(storageLocation: storageLocation, readOnly: true)
 
-            let expectation = self.expectation(description: "agents should be retrieved from database")
-            var agents: [Agent]?
-            var checkpointError: Error?
+        let expectation = self.expectation(description: "agents should be retrieved from database")
+        var agents: [Agent]?
+        var checkpointError: Error?
 
-            // When
-            try connection.busyHandler(.defaultBehavior)
+        // When
+        try connection.busyHandler(.defaultBehavior)
 
-            DispatchQueue.utility.async {
-                do {
-                    agents = try readConnection.query("SELECT * FROM agents")
-                    expectation.fulfill()
-                } catch {
-                    // No-op
-                }
+        DispatchQueue.utility.async {
+            do {
+                agents = try readConnection.query("SELECT * FROM agents")
+                expectation.fulfill()
+            } catch {
+                // No-op
             }
+        }
 
-            DispatchQueue.utility.asyncAfter(seconds: 0.01) {
-                do {
-                    _ = try self.connection.checkpoint(mode: .truncate)
-                } catch {
-                    checkpointError = error
-                }
+        DispatchQueue.utility.asyncAfter(seconds: 0.01) {
+            do {
+                _ = try self.connection.checkpoint(mode: .truncate)
+            } catch {
+                checkpointError = error
             }
+        }
 
-            waitForExpectations(timeout: timeout, handler: nil)
+        waitForExpectations(timeout: timeout, handler: nil)
 
-            // Then
-            XCTAssertEqual(agents?.count, 10_002)
-            XCTAssertNotNil(checkpointError)
+        // Then
+        XCTAssertEqual(agents?.count, 10_002)
+        XCTAssertNotNil(checkpointError)
 
-            if let error = checkpointError as? SQLiteError {
-                XCTAssertEqual(error.code, SQLITE_BUSY)
-                XCTAssertEqual(error.message, "database is locked")
-            }
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+        if let error = checkpointError as? SQLiteError {
+            XCTAssertEqual(error.code, SQLITE_BUSY)
+            XCTAssertEqual(error.message, "database is locked")
         }
     }
 }

--- a/Tests/Tests/Connection/Functions/CheckpointTests.swift
+++ b/Tests/Tests/Connection/Functions/CheckpointTests.swift
@@ -29,111 +29,91 @@ class CheckpointTestCase: BaseConnectionTestCase {
 
     // MARK: - Tests
 
-    func testThatConnectionCanCheckpointDatabaseUsingPassiveCheckpointMode() {
-        do {
-            // Given
-            try TestTables.insertDummyAgents(count: 1_000, connection: connection)
+    func testThatConnectionCanCheckpointDatabaseUsingPassiveCheckpointMode() throws {
+        // Given
+        try TestTables.insertDummyAgents(count: 1_000, connection: connection)
 
-            // When
-            let result = try connection.checkpoint(mode: .passive)
+        // When
+        let result = try connection.checkpoint(mode: .passive)
 
-            // Then
-            XCTAssertEqual(result.logFrames, 15)
-            XCTAssertEqual(result.checkpointedFrames, 15)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(result.logFrames, 15)
+        XCTAssertEqual(result.checkpointedFrames, 15)
     }
 
-    func testThatConnectionCanCheckpointDatabaseUsingFullCheckpointMode() {
-        do {
-            // Given
-            try TestTables.insertDummyAgents(count: 1_000, connection: connection)
+    func testThatConnectionCanCheckpointDatabaseUsingFullCheckpointMode() throws {
+        // Given
+        try TestTables.insertDummyAgents(count: 1_000, connection: connection)
 
-            // When
-            let result = try connection.checkpoint(mode: .full)
+        // When
+        let result = try connection.checkpoint(mode: .full)
 
-            // Then
-            XCTAssertEqual(result.logFrames, 15)
-            XCTAssertEqual(result.checkpointedFrames, 15)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(result.logFrames, 15)
+        XCTAssertEqual(result.checkpointedFrames, 15)
     }
 
-    func testThatConnectionCanCheckpointDatabaseUsingRestartCheckpointMode() {
-        do {
-            // Given
-            try TestTables.insertDummyAgents(count: 1_000, connection: connection)
+    func testThatConnectionCanCheckpointDatabaseUsingRestartCheckpointMode() throws {
+        // Given
+        try TestTables.insertDummyAgents(count: 1_000, connection: connection)
 
-            // When
-            let result = try connection.checkpoint(mode: .restart)
+        // When
+        let result = try connection.checkpoint(mode: .restart)
 
-            // Then
-            XCTAssertEqual(result.logFrames, 15)
-            XCTAssertEqual(result.checkpointedFrames, 15)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(result.logFrames, 15)
+        XCTAssertEqual(result.checkpointedFrames, 15)
     }
 
-    func testThatConnectionCanCheckpointDatabaseUsingTruncateCheckpointMode() {
-        do {
-            // Given
-            try TestTables.insertDummyAgents(count: 1_000, connection: connection)
+    func testThatConnectionCanCheckpointDatabaseUsingTruncateCheckpointMode() throws {
+        // Given
+        try TestTables.insertDummyAgents(count: 1_000, connection: connection)
 
-            // When
-            let result = try connection.checkpoint(mode: .truncate)
+        // When
+        let result = try connection.checkpoint(mode: .truncate)
 
-            // Then
-            XCTAssertEqual(result.logFrames, 0) // CN (8/14/17) - DB is being truncated but results are always 0?
-            XCTAssertEqual(result.checkpointedFrames, 0)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(result.logFrames, 0) // CN (8/14/17) - DB is being truncated but results are always 0?
+        XCTAssertEqual(result.checkpointedFrames, 0)
     }
 
-    func testThatConnectionThrowsBusyErrorWhenCheckpointingBusyDatabase() {
-        do {
-            // Given
-            try TestTables.insertDummyAgents(count: 10_000, connection: connection)
+    func testThatConnectionThrowsBusyErrorWhenCheckpointingBusyDatabase() throws {
+        // Given
+        try TestTables.insertDummyAgents(count: 10_000, connection: connection)
 
-            let readConnection = try Connection(storageLocation: storageLocation, readOnly: true)
+        let readConnection = try Connection(storageLocation: storageLocation, readOnly: true)
 
-            let expectation = self.expectation(description: "agents should be retrieved from database")
-            var agents: [Agent]?
-            var checkpointError: Error?
+        let expectation = self.expectation(description: "agents should be retrieved from database")
+        var agents: [Agent]?
+        var checkpointError: Error?
 
-            // When
-            DispatchQueue.utility.async {
-                do {
-                    agents = try readConnection.query("SELECT * FROM agents")
-                    expectation.fulfill()
-                } catch {
-                    // No-op
-                }
+        // When
+        DispatchQueue.utility.async {
+            do {
+                agents = try readConnection.query("SELECT * FROM agents")
+                expectation.fulfill()
+            } catch {
+                // No-op
             }
+        }
 
-            DispatchQueue.utility.asyncAfter(seconds: 0.01) {
-                do {
-                    _ = try self.connection.checkpoint(mode: .truncate)
-                } catch {
-                    checkpointError = error
-                }
+        DispatchQueue.utility.asyncAfter(seconds: 0.01) {
+            do {
+                _ = try self.connection.checkpoint(mode: .truncate)
+            } catch {
+                checkpointError = error
             }
+        }
 
-            waitForExpectations(timeout: timeout, handler: nil)
+        waitForExpectations(timeout: timeout, handler: nil)
 
-            // Then
-            XCTAssertEqual(agents?.count, 10_002)
-            XCTAssertNotNil(checkpointError)
+        // Then
+        XCTAssertEqual(agents?.count, 10_002)
+        XCTAssertNotNil(checkpointError)
 
-            if let error = checkpointError as? SQLiteError {
-                XCTAssertEqual(error.code, SQLITE_BUSY)
-                XCTAssertEqual(error.message, "database is locked")
-            }
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+        if let error = checkpointError as? SQLiteError {
+            XCTAssertEqual(error.code, SQLITE_BUSY)
+            XCTAssertEqual(error.message, "database is locked")
         }
     }
 }

--- a/Tests/Tests/Connection/Functions/CollationTests.swift
+++ b/Tests/Tests/Connection/Functions/CollationTests.swift
@@ -13,84 +13,72 @@ import SQift
 import XCTest
 
 class CollationTestCase: BaseTestCase {
-    func testThatConnectionCanCreateAndExecuteCustomNumericCollationFunction() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
+    func testThatConnectionCanCreateAndExecuteCustomNumericCollationFunction() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
 
-            connection.createCollation(named: "NUMERIC") { lhs, rhs in
-                return lhs.compare(rhs, options: .numeric, locale: .autoupdatingCurrent)
-            }
-
-            try connection.execute("DROP TABLE IF EXISTS test")
-            try connection.execute("CREATE TABLE test(text TEXT COLLATE 'NUMERIC' NOT NULL)")
-
-            let inserted = ["string 1", "string 21", "string 12", "string 11", "string 02"]
-            let expected = ["string 1", "string 02", "string 11", "string 12", "string 21"]
-
-            try inserted.forEach { try connection.run("INSERT INTO test(text) VALUES(?)", $0) }
-
-            // When
-            let extracted: [String] = try connection.query("SELECT * FROM test ORDER BY text")
-
-            // Then
-            XCTAssertEqual(extracted, expected)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+        connection.createCollation(named: "NUMERIC") { lhs, rhs in
+            return lhs.compare(rhs, options: .numeric, locale: .autoupdatingCurrent)
         }
+
+        try connection.execute("DROP TABLE IF EXISTS test")
+        try connection.execute("CREATE TABLE test(text TEXT COLLATE 'NUMERIC' NOT NULL)")
+
+        let inserted = ["string 1", "string 21", "string 12", "string 11", "string 02"]
+        let expected = ["string 1", "string 02", "string 11", "string 12", "string 21"]
+
+        try inserted.forEach { try connection.run("INSERT INTO test(text) VALUES(?)", $0) }
+
+        // When
+        let extracted: [String] = try connection.query("SELECT * FROM test ORDER BY text")
+
+        // Then
+        XCTAssertEqual(extracted, expected)
     }
 
-    func testThatConnectionCanCreateAndExecuteCustomDiacriticCollationFunction() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            let options: String.CompareOptions = [.literal, .widthInsensitive, .forcedOrdering]
+    func testThatConnectionCanCreateAndExecuteCustomDiacriticCollationFunction() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        let options: String.CompareOptions = [.literal, .widthInsensitive, .forcedOrdering]
 
-            connection.createCollation(named: "DIACRITIC") { lhs, rhs in
-                return lhs.compare(rhs, options: options, locale: .autoupdatingCurrent)
-            }
-
-            try connection.execute("DROP TABLE IF EXISTS test")
-            try connection.execute("CREATE TABLE test(text TEXT COLLATE 'DIACRITIC' NOT NULL)")
-
-            let inserted = ["o", "ô", "ö", "ò", "ó", "œ", "ø", "ō", "õ"]
-            let expected = ["o", "ó", "ò", "ô", "ö", "õ", "ø", "ō", "œ"]
-
-            try inserted.forEach { try connection.run("INSERT INTO test(text) VALUES(?)", $0) }
-
-            // When
-            let extracted: [String] = try connection.query("SELECT * FROM test ORDER BY text")
-
-            // Then
-            XCTAssertEqual(extracted, expected)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+        connection.createCollation(named: "DIACRITIC") { lhs, rhs in
+            return lhs.compare(rhs, options: options, locale: .autoupdatingCurrent)
         }
+
+        try connection.execute("DROP TABLE IF EXISTS test")
+        try connection.execute("CREATE TABLE test(text TEXT COLLATE 'DIACRITIC' NOT NULL)")
+
+        let inserted = ["o", "ô", "ö", "ò", "ó", "œ", "ø", "ō", "õ"]
+        let expected = ["o", "ó", "ò", "ô", "ö", "õ", "ø", "ō", "œ"]
+
+        try inserted.forEach { try connection.run("INSERT INTO test(text) VALUES(?)", $0) }
+
+        // When
+        let extracted: [String] = try connection.query("SELECT * FROM test ORDER BY text")
+
+        // Then
+        XCTAssertEqual(extracted, expected)
     }
 
-    func testThatConnectionCanReplaceCustomCollationFunctionOnTheFly() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
+    func testThatConnectionCanReplaceCustomCollationFunctionOnTheFly() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
 
-            // When
-            connection.createCollation(named: "NODIACRITIC") { lhs, rhs in
-                return lhs.compare(rhs, options: .diacriticInsensitive, locale: .autoupdatingCurrent)
-            }
-
-            let equal1: Bool? = try connection.query("SELECT ? = ? COLLATE 'NODIACRITIC'", "e", "è")
-
-            connection.createCollation(named: "NODIACRITIC") { lhs, rhs in
-                return lhs.compare(rhs, options: [], locale: .autoupdatingCurrent)
-            }
-
-            let equal2: Bool? = try connection.query("SELECT ? = ? COLLATE 'NODIACRITIC'", "e", "è")
-
-            // Then
-            XCTAssertEqual(equal1, true)
-            XCTAssertEqual(equal2, false)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+        // When
+        connection.createCollation(named: "NODIACRITIC") { lhs, rhs in
+            return lhs.compare(rhs, options: .diacriticInsensitive, locale: .autoupdatingCurrent)
         }
+
+        let equal1: Bool? = try connection.query("SELECT ? = ? COLLATE 'NODIACRITIC'", "e", "è")
+
+        connection.createCollation(named: "NODIACRITIC") { lhs, rhs in
+            return lhs.compare(rhs, options: [], locale: .autoupdatingCurrent)
+        }
+
+        let equal2: Bool? = try connection.query("SELECT ? = ? COLLATE 'NODIACRITIC'", "e", "è")
+
+        // Then
+        XCTAssertEqual(equal1, true)
+        XCTAssertEqual(equal2, false)
     }
 }

--- a/Tests/Tests/Connection/Functions/FunctionTests.swift
+++ b/Tests/Tests/Connection/Functions/FunctionTests.swift
@@ -35,154 +35,206 @@ class FunctionTestCase: BaseTestCase {
 
     // MARK: - Tests - Function Values
 
-    func testThatFunctionValueValueAndQueryPropertiesAllWorkAsExpected() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            let date = Date(timeIntervalSince1970: 123456)
+    func testThatFunctionValueValueAndQueryPropertiesAllWorkAsExpected() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        let date = Date(timeIntervalSince1970: 123456)
 
-            try connection.addScalarFunction(named: "sq_value", argumentCount: 2) { _, values in
-                guard values.count == 2, values[0].type == .integer else { return .null }
+        try connection.addScalarFunction(named: "sq_value", argumentCount: 2) { _, values in
+            guard values.count == 2, values[0].type == .integer else { return .null }
 
-                let value1 = values[0]
-                let value2 = values[1]
+            let value1 = values[0]
+            let value2 = values[1]
 
-                switch value1.integer {
-                case 1:
-                    return .integer(value2.integer)
+            switch value1.integer {
+            case 1:
+                return .integer(value2.integer)
 
-                case 2:
-                    return .long(value2.long)
+            case 2:
+                return .long(value2.long)
 
-                case 3:
-                    return .double(value2.double)
+            case 3:
+                return .double(value2.double)
 
-                case 4:
-                    return .text(value2.text)
+            case 4:
+                return .text(value2.text)
 
-                case 5:
-                    guard let date = value2.date else { return .null }
-                    return .date(date)
+            case 5:
+                guard let date = value2.date else { return .null }
+                return .date(date)
 
-                case 6:
-                    return .data(value2.data)
+            case 6:
+                return .data(value2.data)
 
-                case 7:
-                    let buffer = value2.buffer
-                    return .data(Data(bytes: buffer.map { $0 }, count: buffer.count))
+            case 7:
+                let buffer = value2.buffer
+                return .data(Data(bytes: buffer.map { $0 }, count: buffer.count))
 
-                case 8:
-                    return .integer(value2.isNull ? 1 : 0)
+            case 8:
+                return .integer(value2.isNull ? 1 : 0)
 
-                case 9:
-                    return .integer(value2.isInteger ? 1 : 0)
+            case 9:
+                return .integer(value2.isInteger ? 1 : 0)
 
-                case 10:
-                    return .integer(value2.isDouble ? 1 : 0)
+            case 10:
+                return .integer(value2.isDouble ? 1 : 0)
 
-                case 11:
-                    return .integer(value2.isText ? 1 : 0)
+            case 11:
+                return .integer(value2.isText ? 1 : 0)
 
-                case 12:
-                    return .integer(value2.isData ? 1 : 0)
+            case 12:
+                return .integer(value2.isData ? 1 : 0)
 
-                default:
-                    return .null
-                }
+            default:
+                return .null
             }
-
-            let sql = "SELECT sq_value(?, ?)"
-
-            // When
-            let result1: Int? = try connection.prepare(sql, 1, 123).query()
-            let result2: Int64? = try connection.prepare(sql, 2, 123_456_789).query()
-            let result3: Double? = try connection.prepare(sql, 3, 1234.5678).query()
-            let result4: String? = try connection.prepare(sql, 4, text).query()
-            let result5: Date? = try connection.prepare(sql, 5, date).query()
-            let result6: Data? = try connection.prepare(sql, 6, data).query()
-            let result7: Data? = try connection.prepare(sql, 7, data).query()
-            let result8: Bool? = try connection.prepare(sql, 8, nil).query()
-            let result9: Bool? = try connection.prepare(sql, 9, 123).query()
-            let result10: Bool? = try connection.prepare(sql, 10, 12.34).query()
-            let result11: Bool? = try connection.prepare(sql, 11, text).query()
-            let result12: Bool? = try connection.prepare(sql, 12, data).query()
-
-            // Then
-            XCTAssertEqual(result1, 123)
-            XCTAssertEqual(result2, 123_456_789)
-            XCTAssertEqual(result3, 1234.5678)
-            XCTAssertEqual(result4, text)
-            XCTAssertEqual(result5, date)
-            XCTAssertEqual(result6, data)
-            XCTAssertEqual(result7, data)
-            XCTAssertEqual(result8, true)
-            XCTAssertEqual(result9, true)
-            XCTAssertEqual(result10, true)
-            XCTAssertEqual(result11, true)
-            XCTAssertEqual(result12, true)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
         }
+
+        let sql = "SELECT sq_value(?, ?)"
+
+        // When
+        let result1: Int? = try connection.prepare(sql, 1, 123).query()
+        let result2: Int64? = try connection.prepare(sql, 2, 123_456_789).query()
+        let result3: Double? = try connection.prepare(sql, 3, 1234.5678).query()
+        let result4: String? = try connection.prepare(sql, 4, text).query()
+        let result5: Date? = try connection.prepare(sql, 5, date).query()
+        let result6: Data? = try connection.prepare(sql, 6, data).query()
+        let result7: Data? = try connection.prepare(sql, 7, data).query()
+        let result8: Bool? = try connection.prepare(sql, 8, nil).query()
+        let result9: Bool? = try connection.prepare(sql, 9, 123).query()
+        let result10: Bool? = try connection.prepare(sql, 10, 12.34).query()
+        let result11: Bool? = try connection.prepare(sql, 11, text).query()
+        let result12: Bool? = try connection.prepare(sql, 12, data).query()
+
+        // Then
+        XCTAssertEqual(result1, 123)
+        XCTAssertEqual(result2, 123_456_789)
+        XCTAssertEqual(result3, 1234.5678)
+        XCTAssertEqual(result4, text)
+        XCTAssertEqual(result5, date)
+        XCTAssertEqual(result6, data)
+        XCTAssertEqual(result7, data)
+        XCTAssertEqual(result8, true)
+        XCTAssertEqual(result9, true)
+        XCTAssertEqual(result10, true)
+        XCTAssertEqual(result11, true)
+        XCTAssertEqual(result12, true)
     }
 
-    func testThatFunctionValueNumericTypeCanConvertStringsToNumbers() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
+    func testThatFunctionValueNumericTypeCanConvertStringsToNumbers() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
 
-            let intData = "1".data(using: .utf8)!
-            let doubleData = "12.34".data(using: .utf8)!
+        let intData = "1".data(using: .utf8)!
+        let doubleData = "12.34".data(using: .utf8)!
 
-            try connection.addScalarFunction(named: "sq_num_value", argumentCount: 1) { _, values in
-                guard let value = values.first else { return .null }
+        try connection.addScalarFunction(named: "sq_num_value", argumentCount: 1) { _, values in
+            guard let value = values.first else { return .null }
 
-                switch value.numericType {
-                case .null:    return .null
-                case .integer: return .integer(value.integer)
-                case .double:  return .double(value.double)
-                case .text:    return .text(value.text)
-                case .data:    return .data(value.data)
-                }
+            switch value.numericType {
+            case .null:    return .null
+            case .integer: return .integer(value.integer)
+            case .double:  return .double(value.double)
+            case .text:    return .text(value.text)
+            case .data:    return .data(value.data)
             }
-
-            let sql = "SELECT sq_num_value(?)"
-
-            // When
-            let result1: Int64? = try connection.prepare(sql, "123").query()
-            let result2: Int64? = try connection.prepare(sql, intData).query()
-            let result3: Double? = try connection.prepare(sql, "1234.5678").query()
-            let result4: Double? = try connection.prepare(sql, doubleData).query()
-            let result5: String? = try connection.prepare(sql, "12.34").query()
-            let result6: Data? = try connection.prepare(sql, intData).query()
-
-            // Then
-            XCTAssertEqual(result1, 123)
-            XCTAssertEqual(result2, nil)
-            XCTAssertEqual(result3, 1234.5678)
-            XCTAssertEqual(result4, nil)
-            XCTAssertEqual(result5, nil)
-            XCTAssertEqual(result6, intData)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
         }
+
+        let sql = "SELECT sq_num_value(?)"
+
+        // When
+        let result1: Int64? = try connection.prepare(sql, "123").query()
+        let result2: Int64? = try connection.prepare(sql, intData).query()
+        let result3: Double? = try connection.prepare(sql, "1234.5678").query()
+        let result4: Double? = try connection.prepare(sql, doubleData).query()
+        let result5: String? = try connection.prepare(sql, "12.34").query()
+        let result6: Data? = try connection.prepare(sql, intData).query()
+
+        // Then
+        XCTAssertEqual(result1, 123)
+        XCTAssertEqual(result2, nil)
+        XCTAssertEqual(result3, 1234.5678)
+        XCTAssertEqual(result4, nil)
+        XCTAssertEqual(result5, nil)
+        XCTAssertEqual(result6, intData)
     }
 
     // MARK: - Tests - Function Results
 
-    func testThatScalarFunctionCanReturnAllResultTypes() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
+    func testThatScalarFunctionCanReturnAllResultTypes() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
 
-            let text = self.text
-            let date = Date(timeIntervalSince1970: 123456)
-            let data = self.data
-            let zeroData = self.zeroData
+        let text = self.text
+        let date = Date(timeIntervalSince1970: 123456)
+        let data = self.data
+        let zeroData = self.zeroData
 
-            try connection.addScalarFunction(named: "sq_switch", argumentCount: 1) { _, values in
-                guard let value = values.first else { return .null }
+        try connection.addScalarFunction(named: "sq_switch", argumentCount: 1) { _, values in
+            guard let value = values.first else { return .null }
 
-                switch value.integer {
+            switch value.integer {
+            case 0:  return .null
+            case 1:  return .integer(123)
+            case 2:  return .long(123_456_789)
+            case 3:  return .double(1234.5678)
+            case 4:  return .text(text)
+            case 5:  return .date(date)
+            case 6:  return .data(data)
+            case 7:  return .zeroData(10)
+            default: return .null
+            }
+        }
+
+        let sql = "SELECT sq_switch(?)"
+
+        // When
+        let nilResult: Int? = try connection.prepare(sql, 0).query()
+        let intResult: Int? = try connection.prepare(sql, 1).query()
+        let longResult: Int? = try connection.prepare(sql, 2).query()
+        let doubleResult: Double? = try connection.prepare(sql, 3).query()
+        let textResult: String? = try connection.prepare(sql, 4).query()
+        let dateResult: Date? = try connection.prepare(sql, 5).query()
+        let dataResult: Data? = try connection.prepare(sql, 6).query()
+        let zeroDataResult: Data? = try connection.prepare(sql, 7).query()
+
+        // Then
+        XCTAssertEqual(nilResult, nil)
+        XCTAssertEqual(intResult, 123)
+        XCTAssertEqual(longResult, 123_456_789)
+        XCTAssertEqual(doubleResult, 1234.5678)
+        XCTAssertEqual(textResult, text)
+        XCTAssertEqual(dateResult, date)
+        XCTAssertEqual(dataResult, data)
+        XCTAssertEqual(zeroDataResult, zeroData)
+    }
+
+    func testThatAggregateFunctionCanReturnAllResultTypes() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        try loadTablesAndDataForAggregateFunctions(using: connection)
+
+        let text = self.text
+        let date = Date(timeIntervalSince1970: 123456)
+        let data = self.data
+        let zeroData = self.zeroData
+
+        try connection.addAggregateFunction(
+            named: "sq_switch",
+            argumentCount: 1,
+            contextObjectFactory: { return MutableNumber() },
+            stepFunction: { context, values in
+                guard
+                    let value = values.first,
+                    let object = context.stepObject as? MutableNumber
+                    else { return }
+
+                object.number = Int64(value.integer)
+            },
+            finalFunction: { context in
+                guard let object = context.finalObject as? MutableNumber else { return .null }
+
+                switch object.number {
                 case 0:  return .null
                 case 1:  return .integer(123)
                 case 2:  return .long(123_456_789)
@@ -194,111 +246,137 @@ class FunctionTestCase: BaseTestCase {
                 default: return .null
                 }
             }
+        )
 
-            let sql = "SELECT sq_switch(?)"
+        let sql = "SELECT sq_switch(value) FROM sq_values WHERE value = ?"
 
-            // When
-            let nilResult: Int? = try connection.prepare(sql, 0).query()
-            let intResult: Int? = try connection.prepare(sql, 1).query()
-            let longResult: Int? = try connection.prepare(sql, 2).query()
-            let doubleResult: Double? = try connection.prepare(sql, 3).query()
-            let textResult: String? = try connection.prepare(sql, 4).query()
-            let dateResult: Date? = try connection.prepare(sql, 5).query()
-            let dataResult: Data? = try connection.prepare(sql, 6).query()
-            let zeroDataResult: Data? = try connection.prepare(sql, 7).query()
+        // When
+        let nilResult: Int? = try connection.prepare(sql, 0).query()
+        let intResult: Int? = try connection.prepare(sql, 1).query()
+        let longResult: Int? = try connection.prepare(sql, 2).query()
+        let doubleResult: Double? = try connection.prepare(sql, 3).query()
+        let textResult: String? = try connection.prepare(sql, 4).query()
+        let dateResult: Date? = try connection.prepare(sql, 5).query()
+        let dataResult: Data? = try connection.prepare(sql, 6).query()
+        let zeroDataResult: Data? = try connection.prepare(sql, 7).query()
 
-            // Then
-            XCTAssertEqual(nilResult, nil)
-            XCTAssertEqual(intResult, 123)
-            XCTAssertEqual(longResult, 123_456_789)
-            XCTAssertEqual(doubleResult, 1234.5678)
-            XCTAssertEqual(textResult, text)
-            XCTAssertEqual(dateResult, date)
-            XCTAssertEqual(dataResult, data)
-            XCTAssertEqual(zeroDataResult, zeroData)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+        // Then
+        XCTAssertEqual(nilResult, nil)
+        XCTAssertEqual(intResult, 123)
+        XCTAssertEqual(longResult, 123_456_789)
+        XCTAssertEqual(doubleResult, 1234.5678)
+        XCTAssertEqual(textResult, text)
+        XCTAssertEqual(dateResult, date)
+        XCTAssertEqual(dataResult, data)
+        XCTAssertEqual(zeroDataResult, zeroData)
+    }
+
+    func testThatScalarFunctionCanThrowErrorMessagesAndCodes() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+
+        let message = self.errorMessage
+        let messageWithUnicode = self.errorMessageWithUnicode
+
+        try connection.addScalarFunction(named: "sq_throw", argumentCount: 1) { _, values in
+            guard let value = values.first else { return .null }
+
+            switch value.integer {
+            case 0:  return .error(message: message, code: nil)
+            case 1:  return .error(message: messageWithUnicode, code: nil)
+            case 2:  return .error(message: message, code: SQLITE_ERROR)
+            case 3:  return .error(message: message, code: SQLITE_MISUSE)
+            case 4:  return .error(message: messageWithUnicode, code: SQLITE_CORRUPT)
+            default: return .null
+            }
+        }
+
+        let sql = "SELECT sq_throw(?)"
+
+        // When, Then
+        XCTAssertThrowsError(try connection.prepare(sql, 0).run(), "select should throw") { error in
+            if let error = error as? SQLiteError {
+                XCTAssertEqual(error.message, message)
+                XCTAssertEqual(error.code, SQLITE_ERROR)
+            } else {
+                XCTFail("error should be SQLiteError")
+            }
+        }
+
+        XCTAssertThrowsError(try connection.prepare(sql, 1).run(), "select should throw") { error in
+            if let error = error as? SQLiteError {
+                XCTAssertEqual(error.message, messageWithUnicode)
+                XCTAssertEqual(error.code, SQLITE_ERROR)
+            } else {
+                XCTFail("error should be SQLiteError")
+            }
+        }
+
+        XCTAssertThrowsError(try connection.prepare(sql, 2).run(), "select should throw") { error in
+            if let error = error as? SQLiteError {
+                XCTAssertEqual(error.message, message)
+                XCTAssertEqual(error.code, SQLITE_ERROR)
+            } else {
+                XCTFail("error should be SQLiteError")
+            }
+        }
+
+        XCTAssertThrowsError(try connection.prepare(sql, 3).run(), "select should throw") { error in
+            if let error = error as? SQLiteError {
+                XCTAssertEqual(error.message, message)
+                XCTAssertEqual(error.code, SQLITE_MISUSE)
+            } else {
+                XCTFail("error should be SQLiteError")
+            }
+        }
+
+        XCTAssertThrowsError(try connection.prepare(sql, 4).run(), "select should throw") { error in
+            if let error = error as? SQLiteError {
+                XCTAssertEqual(error.message, messageWithUnicode)
+                XCTAssertEqual(error.code, SQLITE_CORRUPT)
+            } else {
+                XCTFail("error should be SQLiteError")
+            }
         }
     }
 
-    func testThatAggregateFunctionCanReturnAllResultTypes() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            try loadTablesAndDataForAggregateFunctions(using: connection)
+    func testThatAggregateFunctionCanThrowErrorMessagesAndCodes() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        try loadTablesAndDataForAggregateFunctions(using: connection)
 
-            let text = self.text
-            let date = Date(timeIntervalSince1970: 123456)
-            let data = self.data
-            let zeroData = self.zeroData
+        let message = self.errorMessage
+        let messageWithUnicode = self.errorMessageWithUnicode
 
-            try connection.addAggregateFunction(
-                named: "sq_switch",
-                argumentCount: 1,
-                contextObjectFactory: { return MutableNumber() },
-                stepFunction: { context, values in
-                    guard
-                        let value = values.first,
-                        let object = context.stepObject as? MutableNumber
+        try connection.addScalarFunction(named: "sq_throw", argumentCount: 1) { _, values in
+            guard let value = values.first else { return .null }
+
+            switch value.integer {
+            case 0:  return .error(message: message, code: nil)
+            case 1:  return .error(message: messageWithUnicode, code: nil)
+            case 2:  return .error(message: message, code: SQLITE_ERROR)
+            case 3:  return .error(message: message, code: SQLITE_MISUSE)
+            case 4:  return .error(message: messageWithUnicode, code: SQLITE_CORRUPT)
+            default: return .null
+            }
+        }
+
+        try connection.addAggregateFunction(
+            named: "sq_switch",
+            argumentCount: 1,
+            contextObjectFactory: { return MutableNumber() },
+            stepFunction: { context, values in
+                guard
+                    let value = values.first,
+                    let object = context.stepObject as? MutableNumber
                     else { return }
 
-                    object.number = Int64(value.integer)
-                },
-                finalFunction: { context in
-                    guard let object = context.finalObject as? MutableNumber else { return .null }
+                object.number = Int64(value.integer)
+            },
+            finalFunction: { context in
+                guard let object = context.finalObject as? MutableNumber else { return .null }
 
-                    switch object.number {
-                    case 0:  return .null
-                    case 1:  return .integer(123)
-                    case 2:  return .long(123_456_789)
-                    case 3:  return .double(1234.5678)
-                    case 4:  return .text(text)
-                    case 5:  return .date(date)
-                    case 6:  return .data(data)
-                    case 7:  return .zeroData(10)
-                    default: return .null
-                    }
-                }
-            )
-
-            let sql = "SELECT sq_switch(value) FROM sq_values WHERE value = ?"
-
-            // When
-            let nilResult: Int? = try connection.prepare(sql, 0).query()
-            let intResult: Int? = try connection.prepare(sql, 1).query()
-            let longResult: Int? = try connection.prepare(sql, 2).query()
-            let doubleResult: Double? = try connection.prepare(sql, 3).query()
-            let textResult: String? = try connection.prepare(sql, 4).query()
-            let dateResult: Date? = try connection.prepare(sql, 5).query()
-            let dataResult: Data? = try connection.prepare(sql, 6).query()
-            let zeroDataResult: Data? = try connection.prepare(sql, 7).query()
-
-            // Then
-            XCTAssertEqual(nilResult, nil)
-            XCTAssertEqual(intResult, 123)
-            XCTAssertEqual(longResult, 123_456_789)
-            XCTAssertEqual(doubleResult, 1234.5678)
-            XCTAssertEqual(textResult, text)
-            XCTAssertEqual(dateResult, date)
-            XCTAssertEqual(dataResult, data)
-            XCTAssertEqual(zeroDataResult, zeroData)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
-    }
-
-    func testThatScalarFunctionCanThrowErrorMessagesAndCodes() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-
-            let message = self.errorMessage
-            let messageWithUnicode = self.errorMessageWithUnicode
-
-            try connection.addScalarFunction(named: "sq_throw", argumentCount: 1) { _, values in
-                guard let value = values.first else { return .null }
-
-                switch value.integer {
+                switch object.number {
                 case 0:  return .error(message: message, code: nil)
                 case 1:  return .error(message: messageWithUnicode, code: nil)
                 case 2:  return .error(message: message, code: SQLITE_ERROR)
@@ -307,684 +385,526 @@ class FunctionTestCase: BaseTestCase {
                 default: return .null
                 }
             }
+        )
 
-            let sql = "SELECT sq_throw(?)"
+        let sql = "SELECT sq_throw(value) FROM sq_values WHERE value = ?"
 
-            // When
-            XCTAssertThrowsError(try connection.prepare(sql, 0).run(), "select should throw") { error in
-                if let error = error as? SQLiteError {
-                    XCTAssertEqual(error.message, message)
-                    XCTAssertEqual(error.code, SQLITE_ERROR)
-                } else {
-                    XCTFail("error should be SQLiteError")
-                }
+        // When, Then
+        XCTAssertThrowsError(try connection.prepare(sql, 0).run(), "select should throw") { error in
+            if let error = error as? SQLiteError {
+                XCTAssertEqual(error.message, message)
+                XCTAssertEqual(error.code, SQLITE_ERROR)
+            } else {
+                XCTFail("error should be SQLiteError")
             }
+        }
 
-            XCTAssertThrowsError(try connection.prepare(sql, 1).run(), "select should throw") { error in
-                if let error = error as? SQLiteError {
-                    XCTAssertEqual(error.message, messageWithUnicode)
-                    XCTAssertEqual(error.code, SQLITE_ERROR)
-                } else {
-                    XCTFail("error should be SQLiteError")
-                }
+        XCTAssertThrowsError(try connection.prepare(sql, 1).run(), "select should throw") { error in
+            if let error = error as? SQLiteError {
+                XCTAssertEqual(error.message, messageWithUnicode)
+                XCTAssertEqual(error.code, SQLITE_ERROR)
+            } else {
+                XCTFail("error should be SQLiteError")
             }
+        }
 
-            XCTAssertThrowsError(try connection.prepare(sql, 2).run(), "select should throw") { error in
-                if let error = error as? SQLiteError {
-                    XCTAssertEqual(error.message, message)
-                    XCTAssertEqual(error.code, SQLITE_ERROR)
-                } else {
-                    XCTFail("error should be SQLiteError")
-                }
+        XCTAssertThrowsError(try connection.prepare(sql, 2).run(), "select should throw") { error in
+            if let error = error as? SQLiteError {
+                XCTAssertEqual(error.message, message)
+                XCTAssertEqual(error.code, SQLITE_ERROR)
+            } else {
+                XCTFail("error should be SQLiteError")
             }
+        }
 
-            XCTAssertThrowsError(try connection.prepare(sql, 3).run(), "select should throw") { error in
-                if let error = error as? SQLiteError {
-                    XCTAssertEqual(error.message, message)
-                    XCTAssertEqual(error.code, SQLITE_MISUSE)
-                } else {
-                    XCTFail("error should be SQLiteError")
-                }
+        XCTAssertThrowsError(try connection.prepare(sql, 3).run(), "select should throw") { error in
+            if let error = error as? SQLiteError {
+                XCTAssertEqual(error.message, message)
+                XCTAssertEqual(error.code, SQLITE_MISUSE)
+            } else {
+                XCTFail("error should be SQLiteError")
             }
+        }
 
-            XCTAssertThrowsError(try connection.prepare(sql, 4).run(), "select should throw") { error in
-                if let error = error as? SQLiteError {
-                    XCTAssertEqual(error.message, messageWithUnicode)
-                    XCTAssertEqual(error.code, SQLITE_CORRUPT)
-                } else {
-                    XCTFail("error should be SQLiteError")
-                }
+        XCTAssertThrowsError(try connection.prepare(sql, 4).run(), "select should throw") { error in
+            if let error = error as? SQLiteError {
+                XCTAssertEqual(error.message, messageWithUnicode)
+                XCTAssertEqual(error.code, SQLITE_CORRUPT)
+            } else {
+                XCTFail("error should be SQLiteError")
             }
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
         }
     }
 
-    func testThatAggregateFunctionCanThrowErrorMessagesAndCodes() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            try loadTablesAndDataForAggregateFunctions(using: connection)
+    func testThatScalarFunctionIsNotCalledAndShutsDownProperlyWhenNoResultsAreFound() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        try loadTablesAndDataForAggregateFunctions(using: connection)
 
-            let message = self.errorMessage
-            let messageWithUnicode = self.errorMessageWithUnicode
+        try connection.addScalarFunction(named: "sq_echo", argumentCount: 1) { _, _ in return .integer(1) }
 
-            try connection.addScalarFunction(named: "sq_throw", argumentCount: 1) { _, values in
-                guard let value = values.first else { return .null }
+        // When
+        let result: Int64? = try connection.prepare("SELECT sq_echo(?) FROM sq_values WHERE value = 'invalid'").query()
 
-                switch value.integer {
-                case 0:  return .error(message: message, code: nil)
-                case 1:  return .error(message: messageWithUnicode, code: nil)
-                case 2:  return .error(message: message, code: SQLITE_ERROR)
-                case 3:  return .error(message: message, code: SQLITE_MISUSE)
-                case 4:  return .error(message: messageWithUnicode, code: SQLITE_CORRUPT)
-                default: return .null
-                }
-            }
-
-            try connection.addAggregateFunction(
-                named: "sq_switch",
-                argumentCount: 1,
-                contextObjectFactory: { return MutableNumber() },
-                stepFunction: { context, values in
-                    guard
-                        let value = values.first,
-                        let object = context.stepObject as? MutableNumber
-                        else { return }
-
-                    object.number = Int64(value.integer)
-                },
-                finalFunction: { context in
-                    guard let object = context.finalObject as? MutableNumber else { return .null }
-
-                    switch object.number {
-                    case 0:  return .error(message: message, code: nil)
-                    case 1:  return .error(message: messageWithUnicode, code: nil)
-                    case 2:  return .error(message: message, code: SQLITE_ERROR)
-                    case 3:  return .error(message: message, code: SQLITE_MISUSE)
-                    case 4:  return .error(message: messageWithUnicode, code: SQLITE_CORRUPT)
-                    default: return .null
-                    }
-                }
-            )
-
-            let sql = "SELECT sq_throw(value) FROM sq_values WHERE value = ?"
-
-            // When
-            XCTAssertThrowsError(try connection.prepare(sql, 0).run(), "select should throw") { error in
-                if let error = error as? SQLiteError {
-                    XCTAssertEqual(error.message, message)
-                    XCTAssertEqual(error.code, SQLITE_ERROR)
-                } else {
-                    XCTFail("error should be SQLiteError")
-                }
-            }
-
-            XCTAssertThrowsError(try connection.prepare(sql, 1).run(), "select should throw") { error in
-                if let error = error as? SQLiteError {
-                    XCTAssertEqual(error.message, messageWithUnicode)
-                    XCTAssertEqual(error.code, SQLITE_ERROR)
-                } else {
-                    XCTFail("error should be SQLiteError")
-                }
-            }
-
-            XCTAssertThrowsError(try connection.prepare(sql, 2).run(), "select should throw") { error in
-                if let error = error as? SQLiteError {
-                    XCTAssertEqual(error.message, message)
-                    XCTAssertEqual(error.code, SQLITE_ERROR)
-                } else {
-                    XCTFail("error should be SQLiteError")
-                }
-            }
-
-            XCTAssertThrowsError(try connection.prepare(sql, 3).run(), "select should throw") { error in
-                if let error = error as? SQLiteError {
-                    XCTAssertEqual(error.message, message)
-                    XCTAssertEqual(error.code, SQLITE_MISUSE)
-                } else {
-                    XCTFail("error should be SQLiteError")
-                }
-            }
-
-            XCTAssertThrowsError(try connection.prepare(sql, 4).run(), "select should throw") { error in
-                if let error = error as? SQLiteError {
-                    XCTAssertEqual(error.message, messageWithUnicode)
-                    XCTAssertEqual(error.code, SQLITE_CORRUPT)
-                } else {
-                    XCTFail("error should be SQLiteError")
-                }
-            }
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(result, nil)
     }
 
-    func testThatScalarFunctionIsNotCalledAndShutsDownProperlyWhenNoResultsAreFound() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            try loadTablesAndDataForAggregateFunctions(using: connection)
+    func testThatAggregateFunctionIsNotCalledAndShutsDownProperlyWhenNoResultsAreFound() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        try loadTablesAndDataForAggregateFunctions(using: connection)
 
-            try connection.addScalarFunction(named: "sq_echo", argumentCount: 1) { _, _ in return .integer(1) }
+        try connection.addAggregateFunction(
+            named: "sq_echo",
+            argumentCount: 1,
+            contextObjectFactory: { return MutableNumber() },
+            stepFunction: { _, _ in },
+            finalFunction: { _ in return .null }
+        )
 
-            // When
-            let result: Int64? = try connection.prepare("SELECT sq_echo(?) FROM sq_values WHERE value = 'invalid'").query()
+        // When
+        let result: Int64? = try connection.prepare("SELECT sq_echo(?) FROM sq_values WHERE value = 'invalid'").query()
 
-            // Then
-            XCTAssertEqual(result, nil)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
-    }
-
-    func testThatAggregateFunctionIsNotCalledAndShutsDownProperlyWhenNoResultsAreFound() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            try loadTablesAndDataForAggregateFunctions(using: connection)
-
-            try connection.addAggregateFunction(
-                named: "sq_echo",
-                argumentCount: 1,
-                contextObjectFactory: { return MutableNumber() },
-                stepFunction: { _, _ in },
-                finalFunction: { _ in return .null }
-            )
-
-            // When
-            let result: Int64? = try connection.prepare("SELECT sq_echo(?) FROM sq_values WHERE value = 'invalid'").query()
-
-            // Then
-            XCTAssertEqual(result, nil)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(result, nil)
     }
 
     // MARK: - Tests - Add / Remove Functions
 
-    func testThatMultipleScalarFunctionsWithSameNameAndDifferentArgumentCountCanBeAdded() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
+    func testThatMultipleScalarFunctionsWithSameNameAndDifferentArgumentCountCanBeAdded() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
 
-            try connection.addScalarFunction(named: "sq_echo", argumentCount: 1) { _, _ in return .integer(1) }
-            try connection.addScalarFunction(named: "sq_echo", argumentCount: 2) { _, _ in return .integer(2) }
-            try connection.addScalarFunction(named: "sq_echo", argumentCount: 3) { _, _ in return .integer(3) }
-            try connection.addScalarFunction(named: "sq_echo", argumentCount: 4) { _, _ in return .integer(4) }
+        try connection.addScalarFunction(named: "sq_echo", argumentCount: 1) { _, _ in return .integer(1) }
+        try connection.addScalarFunction(named: "sq_echo", argumentCount: 2) { _, _ in return .integer(2) }
+        try connection.addScalarFunction(named: "sq_echo", argumentCount: 3) { _, _ in return .integer(3) }
+        try connection.addScalarFunction(named: "sq_echo", argumentCount: 4) { _, _ in return .integer(4) }
 
-            // When
-            let result1: Int64? = try connection.prepare("SELECT sq_echo(?)", 1).query()
-            let result2: Int64? = try connection.prepare("SELECT sq_echo(?, ?)", 1, 2).query()
-            let result3: Int64? = try connection.prepare("SELECT sq_echo(?, ?, ?)", 1, 2, 3).query()
-            let result4: Int64? = try connection.prepare("SELECT sq_echo(?, ?, ?, ?)", 1, 2, 3, 4).query()
+        // When
+        let result1: Int64? = try connection.prepare("SELECT sq_echo(?)", 1).query()
+        let result2: Int64? = try connection.prepare("SELECT sq_echo(?, ?)", 1, 2).query()
+        let result3: Int64? = try connection.prepare("SELECT sq_echo(?, ?, ?)", 1, 2, 3).query()
+        let result4: Int64? = try connection.prepare("SELECT sq_echo(?, ?, ?, ?)", 1, 2, 3, 4).query()
 
-            // Then
-            XCTAssertEqual(result1, 1)
-            XCTAssertEqual(result2, 2)
-            XCTAssertEqual(result3, 3)
-            XCTAssertEqual(result4, 4)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(result1, 1)
+        XCTAssertEqual(result2, 2)
+        XCTAssertEqual(result3, 3)
+        XCTAssertEqual(result4, 4)
     }
 
-    func testThatMultipleAggregateFunctionsWithSameNameAndDifferentArgumentCountCanBeAdded() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            try loadTablesAndDataForAggregateFunctions(using: connection)
+    func testThatMultipleAggregateFunctionsWithSameNameAndDifferentArgumentCountCanBeAdded() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        try loadTablesAndDataForAggregateFunctions(using: connection)
 
-            try connection.addAggregateFunction(
-                named: "sq_echo",
-                argumentCount: 1,
-                contextObjectFactory: { return MutableNumber() },
-                stepFunction: { _, _ in },
-                finalFunction: { _ in return .integer(1) }
-            )
+        try connection.addAggregateFunction(
+            named: "sq_echo",
+            argumentCount: 1,
+            contextObjectFactory: { return MutableNumber() },
+            stepFunction: { _, _ in },
+            finalFunction: { _ in return .integer(1) }
+        )
 
-            try connection.addAggregateFunction(
-                named: "sq_echo",
-                argumentCount: 2,
-                contextObjectFactory: { return MutableNumber() },
-                stepFunction: { _, _ in },
-                finalFunction: { _ in return .integer(2) }
-            )
+        try connection.addAggregateFunction(
+            named: "sq_echo",
+            argumentCount: 2,
+            contextObjectFactory: { return MutableNumber() },
+            stepFunction: { _, _ in },
+            finalFunction: { _ in return .integer(2) }
+        )
 
-            try connection.addAggregateFunction(
-                named: "sq_echo",
-                argumentCount: 3,
-                contextObjectFactory: { return MutableNumber() },
-                stepFunction: { _, _ in },
-                finalFunction: { _ in return .integer(3) }
-            )
+        try connection.addAggregateFunction(
+            named: "sq_echo",
+            argumentCount: 3,
+            contextObjectFactory: { return MutableNumber() },
+            stepFunction: { _, _ in },
+            finalFunction: { _ in return .integer(3) }
+        )
 
-            try connection.addAggregateFunction(
-                named: "sq_echo",
-                argumentCount: 4,
-                contextObjectFactory: { return MutableNumber() },
-                stepFunction: { _, _ in },
-                finalFunction: { _ in return .integer(4) }
-            )
+        try connection.addAggregateFunction(
+            named: "sq_echo",
+            argumentCount: 4,
+            contextObjectFactory: { return MutableNumber() },
+            stepFunction: { _, _ in },
+            finalFunction: { _ in return .integer(4) }
+        )
 
-            // When
-            let result1: Int64? = try connection.prepare("SELECT sq_echo(?) FROM sq_values", 1).query()
-            let result2: Int64? = try connection.prepare("SELECT sq_echo(?, ?) FROM sq_values", 1, 2).query()
-            let result3: Int64? = try connection.prepare("SELECT sq_echo(?, ?, ?) FROM sq_values", 1, 2, 3).query()
-            let result4: Int64? = try connection.prepare("SELECT sq_echo(?, ?, ?, ?) FROM sq_values", 1, 2, 3, 4).query()
+        // When
+        let result1: Int64? = try connection.prepare("SELECT sq_echo(?) FROM sq_values", 1).query()
+        let result2: Int64? = try connection.prepare("SELECT sq_echo(?, ?) FROM sq_values", 1, 2).query()
+        let result3: Int64? = try connection.prepare("SELECT sq_echo(?, ?, ?) FROM sq_values", 1, 2, 3).query()
+        let result4: Int64? = try connection.prepare("SELECT sq_echo(?, ?, ?, ?) FROM sq_values", 1, 2, 3, 4).query()
 
-            // Then
-            XCTAssertEqual(result1, 1)
-            XCTAssertEqual(result2, 2)
-            XCTAssertEqual(result3, 3)
-            XCTAssertEqual(result4, 4)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(result1, 1)
+        XCTAssertEqual(result2, 2)
+        XCTAssertEqual(result3, 3)
+        XCTAssertEqual(result4, 4)
     }
 
-    func testThatScalarFunctionsCanBeRemovedAtRuntime() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
+    func testThatScalarFunctionsCanBeRemovedAtRuntime() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
 
-            // When
-            try connection.addScalarFunction(named: "sq_echo", argumentCount: 1) { _, _ in return .integer(1) }
-            let result1: Int64? = try connection.prepare("SELECT sq_echo(?)", 1).query()
+        // When
+        try connection.addScalarFunction(named: "sq_echo", argumentCount: 1) { _, _ in return .integer(1) }
+        let result1: Int64? = try connection.prepare("SELECT sq_echo(?)", 1).query()
 
-            try connection.removeFunction(named: "sq_echo", argumentCount: 1)
-            XCTAssertThrowsError(try connection.prepare("SELECT sq_echo(?)", 1).run())
+        try connection.removeFunction(named: "sq_echo", argumentCount: 1)
+        XCTAssertThrowsError(try connection.prepare("SELECT sq_echo(?)", 1).run())
 
-            try connection.addScalarFunction(named: "sq_echo", argumentCount: 1) { _, _ in return .integer(1) }
-            let result2: Int64? = try connection.prepare("SELECT sq_echo(?)", 1).query()
+        try connection.addScalarFunction(named: "sq_echo", argumentCount: 1) { _, _ in return .integer(1) }
+        let result2: Int64? = try connection.prepare("SELECT sq_echo(?)", 1).query()
 
-            // Then
-            XCTAssertEqual(result1, 1)
-            XCTAssertEqual(result2, 1)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(result1, 1)
+        XCTAssertEqual(result2, 1)
     }
 
-    func testThatAggregateFunctionsCanBeRemovedAtRuntime() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
+    func testThatAggregateFunctionsCanBeRemovedAtRuntime() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
 
-            // When
-            try connection.addAggregateFunction(
-                named: "sq_echo",
-                argumentCount: 1,
-                contextObjectFactory: { return MutableNumber() },
-                stepFunction: { _, _ in },
-                finalFunction: { _ in return .integer(1) }
-            )
+        // When
+        try connection.addAggregateFunction(
+            named: "sq_echo",
+            argumentCount: 1,
+            contextObjectFactory: { return MutableNumber() },
+            stepFunction: { _, _ in },
+            finalFunction: { _ in return .integer(1) }
+        )
 
-            let result1: Int64? = try connection.prepare("SELECT sq_echo(?)", 1).query()
+        let result1: Int64? = try connection.prepare("SELECT sq_echo(?)", 1).query()
 
-            try connection.removeFunction(named: "sq_echo", argumentCount: 1)
-            XCTAssertThrowsError(try connection.prepare("SELECT sq_echo(?)", 1).run())
+        try connection.removeFunction(named: "sq_echo", argumentCount: 1)
+        XCTAssertThrowsError(try connection.prepare("SELECT sq_echo(?)", 1).run())
 
-            try connection.addAggregateFunction(
-                named: "sq_echo",
-                argumentCount: 1,
-                contextObjectFactory: { return MutableNumber() },
-                stepFunction: { _, _ in },
-                finalFunction: { _ in return .integer(1) }
-            )
+        try connection.addAggregateFunction(
+            named: "sq_echo",
+            argumentCount: 1,
+            contextObjectFactory: { return MutableNumber() },
+            stepFunction: { _, _ in },
+            finalFunction: { _ in return .integer(1) }
+        )
 
-            let result2: Int64? = try connection.prepare("SELECT sq_echo(?)", 1).query()
+        let result2: Int64? = try connection.prepare("SELECT sq_echo(?)", 1).query()
 
-            // Then
-            XCTAssertEqual(result1, 1)
-            XCTAssertEqual(result2, 1)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(result1, 1)
+        XCTAssertEqual(result2, 1)
     }
 
     // MARK: - Scalar Functions
 
-    func testThatScalarFunctionCanOutputTheSameInputValues() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
+    func testThatScalarFunctionCanOutputTheSameInputValues() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
 
-            let text = self.text
-            let textWithUnicode = self.textWithUnicode
-            let data = self.data
+        let text = self.text
+        let textWithUnicode = self.textWithUnicode
+        let data = self.data
 
-            try connection.addScalarFunction(named: "sq_echo", argumentCount: 1) { _, values in
-                guard let value = values.first else { return .null }
+        try connection.addScalarFunction(named: "sq_echo", argumentCount: 1) { _, values in
+            guard let value = values.first else { return .null }
 
-                switch value.type {
-                case .null:    return .null
-                case .integer: return .integer(value.integer)
-                case .double:  return .double(value.double)
-                case .text:    return .text(value.text)
-                case .data:    return .data(value.data)
-                }
+            switch value.type {
+            case .null:    return .null
+            case .integer: return .integer(value.integer)
+            case .double:  return .double(value.double)
+            case .text:    return .text(value.text)
+            case .data:    return .data(value.data)
             }
-
-            let sql = "SELECT sq_echo(?)"
-
-            // When
-            let nilResult: Int? = try connection.prepare(sql, nil).query()
-            let intResult: Int? = try connection.prepare(sql, 10).query()
-            let doubleResult: Double? = try connection.prepare(sql, 1234.5678).query()
-            let textResult: String? = try connection.prepare(sql, text).query()
-            let textWithUnicodeResult: String? = try connection.prepare(sql, textWithUnicode).query()
-            let dataResult: Data? = try connection.prepare(sql, data).query()
-
-            // Then
-            XCTAssertEqual(nilResult, nil)
-            XCTAssertEqual(intResult, 10)
-            XCTAssertEqual(doubleResult, 1234.5678)
-            XCTAssertEqual(textResult, text)
-            XCTAssertEqual(textWithUnicodeResult, textWithUnicode)
-            XCTAssertEqual(dataResult, data)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
         }
+
+        let sql = "SELECT sq_echo(?)"
+
+        // When
+        let nilResult: Int? = try connection.prepare(sql, nil).query()
+        let intResult: Int? = try connection.prepare(sql, 10).query()
+        let doubleResult: Double? = try connection.prepare(sql, 1234.5678).query()
+        let textResult: String? = try connection.prepare(sql, text).query()
+        let textWithUnicodeResult: String? = try connection.prepare(sql, textWithUnicode).query()
+        let dataResult: Data? = try connection.prepare(sql, data).query()
+
+        // Then
+        XCTAssertEqual(nilResult, nil)
+        XCTAssertEqual(intResult, 10)
+        XCTAssertEqual(doubleResult, 1234.5678)
+        XCTAssertEqual(textResult, text)
+        XCTAssertEqual(textWithUnicodeResult, textWithUnicode)
+        XCTAssertEqual(dataResult, data)
     }
 
-    func testThatScalarFunctionCanAddMultipleInputValues() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
+    func testThatScalarFunctionCanAddMultipleInputValues() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
 
-            let data1 = "â".data(using: .utf8)!
-            let data2 = "ć".data(using: .utf8)!
-            let data3 = "âć".data(using: .utf8)!
+        let data1 = "â".data(using: .utf8)!
+        let data2 = "ć".data(using: .utf8)!
+        let data3 = "âć".data(using: .utf8)!
 
-            try connection.addScalarFunction(named: "sq_add", argumentCount: 2) { _, values in
-                guard values.count == 2 else { return .null }
+        try connection.addScalarFunction(named: "sq_add", argumentCount: 2) { _, values in
+            guard values.count == 2 else { return .null }
 
-                let value1 = values[0]
-                let value2 = values[1]
+            let value1 = values[0]
+            let value2 = values[1]
 
-                switch (value1.type, value2.type) {
-                case (.integer, .integer):
-                    return .integer(value1.integer + value2.integer)
+            switch (value1.type, value2.type) {
+            case (.integer, .integer):
+                return .integer(value1.integer + value2.integer)
 
-                case (.double, .double):
-                    return .double(value1.double + value2.double)
+            case (.double, .double):
+                return .double(value1.double + value2.double)
 
-                case (.text, .text):
-                    return .text(value1.text + value2.text)
+            case (.text, .text):
+                return .text(value1.text + value2.text)
 
-                case (.data, .data):
-                    return .data(value1.data + value2.data)
+            case (.data, .data):
+                return .data(value1.data + value2.data)
 
-                default:
-                    return .null
-                }
+            default:
+                return .null
             }
-
-            let sql = "SELECT sq_add(?, ?)"
-
-            // When
-            let nilResult: Int? = try connection.prepare(sql, nil, nil).query()
-            let intResult: Int? = try connection.prepare(sql, 1, 2).query()
-            let doubleResult: Double? = try connection.prepare(sql, 12.34, 56.78).query()
-            let textResult: String? = try connection.prepare(sql, "a", "b").query()
-            let textWithUnicodeResult: String? = try connection.prepare(sql, "á", "b").query()
-            let dataResult: Data? = try connection.prepare(sql, data1, data2).query()
-
-            // Then
-            XCTAssertEqual(nilResult, nil)
-            XCTAssertEqual(intResult, 3)
-            XCTAssertEqual(doubleResult, 69.12)
-            XCTAssertEqual(textResult, "ab")
-            XCTAssertEqual(textWithUnicodeResult, "áb")
-            XCTAssertEqual(dataResult, data3)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
         }
+
+        let sql = "SELECT sq_add(?, ?)"
+
+        // When
+        let nilResult: Int? = try connection.prepare(sql, nil, nil).query()
+        let intResult: Int? = try connection.prepare(sql, 1, 2).query()
+        let doubleResult: Double? = try connection.prepare(sql, 12.34, 56.78).query()
+        let textResult: String? = try connection.prepare(sql, "a", "b").query()
+        let textWithUnicodeResult: String? = try connection.prepare(sql, "á", "b").query()
+        let dataResult: Data? = try connection.prepare(sql, data1, data2).query()
+
+        // Then
+        XCTAssertEqual(nilResult, nil)
+        XCTAssertEqual(intResult, 3)
+        XCTAssertEqual(doubleResult, 69.12)
+        XCTAssertEqual(textResult, "ab")
+        XCTAssertEqual(textWithUnicodeResult, "áb")
+        XCTAssertEqual(dataResult, data3)
     }
 
-    func testThatScalarFunctionCanReuseAuxilaryDataForConstantExpressions() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            try loadTablesAndDataForAggregateFunctions(using: connection)
+    func testThatScalarFunctionCanReuseAuxilaryDataForConstantExpressions() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        try loadTablesAndDataForAggregateFunctions(using: connection)
 
-            var dateFormattersInitializedCount = 0
+        var dateFormattersInitializedCount = 0
 
-            try connection.addScalarFunction(named: "format_date", argumentCount: 2) { context, values in
-                guard values.count == 2 else { return .null }
+        try connection.addScalarFunction(named: "format_date", argumentCount: 2) { context, values in
+            guard values.count == 2 else { return .null }
 
-                let value1 = values[0]
-                let value2 = values[1]
+            let value1 = values[0]
+            let value2 = values[1]
 
-                guard value1.isText, value2.isInteger, let integer = UInt32(exactly: value2.integer) else { return .null }
+            guard value1.isText, value2.isInteger, let integer = UInt32(exactly: value2.integer) else { return .null }
 
-                let dateFormat = value1.text
-                let date = Date(timeIntervalSince1970: 10_000.0 * TimeInterval(integer))
+            let dateFormat = value1.text
+            let date = Date(timeIntervalSince1970: 10_000.0 * TimeInterval(integer))
 
-                let dateFormatter = context.auxilaryData[0] as? DateFormatter ?? {
-                    let dateFormatter = DateFormatter()
+            let dateFormatter = context.auxilaryData[0] as? DateFormatter ?? {
+                let dateFormatter = DateFormatter()
 
-                    dateFormatter.dateFormat = dateFormat
-                    dateFormatter.locale = Locale(identifier: "en_US_POSIX")
-                    dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
+                dateFormatter.dateFormat = dateFormat
+                dateFormatter.locale = Locale(identifier: "en_US_POSIX")
+                dateFormatter.timeZone = TimeZone(secondsFromGMT: 0)
 
-                    context.auxilaryData[0] = dateFormatter
+                context.auxilaryData[0] = dateFormatter
 
-                    dateFormattersInitializedCount += 1
+                dateFormattersInitializedCount += 1
 
-                    return dateFormatter
+                return dateFormatter
                 }()
 
-                return .text(dateFormatter.string(from: date))
-            }
-
-            let sql = "SELECT format_date(?, value) FROM sq_values"
-
-            // When
-            let results: [Date?] = try connection.query(sql, "yyyy-MM-dd'T'HH:mm:ss.SSS")
-
-            // Then
-            XCTAssertEqual(dateFormattersInitializedCount, 1)
-            XCTAssertEqual(results.count, 10)
-            results.forEach { XCTAssertNotNil($0) }
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+            return .text(dateFormatter.string(from: date))
         }
+
+        let sql = "SELECT format_date(?, value) FROM sq_values"
+
+        // When
+        let results: [Date?] = try connection.query(sql, "yyyy-MM-dd'T'HH:mm:ss.SSS")
+
+        // Then
+        XCTAssertEqual(dateFormattersInitializedCount, 1)
+        XCTAssertEqual(results.count, 10)
+        results.forEach { XCTAssertNotNil($0) }
     }
 
-    func testThatScalarFunctionThrowsWhenCalledWithInvalidNumberOfArguments() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
+    func testThatScalarFunctionThrowsWhenCalledWithInvalidNumberOfArguments() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
 
-            try connection.addScalarFunction(named: "sq_echo", argumentCount: 1) { _, _ in
-                return .integer(1)
-            }
-
-            try connection.addScalarFunction(named: "sq_variable_echo", argumentCount: -1) { _, args in
-                return .integer(Int32(args.count))
-            }
-
-            // When
-            let result1: Int64? = try connection.prepare("SELECT sq_echo(?)", 1).query()
-            let result2: Int64? = try connection.prepare("SELECT sq_variable_echo(?)", 1).query()
-            let result3: Int64? = try connection.prepare("SELECT sq_variable_echo(?, ?)", 1, 2).query()
-            let result4: Int64? = try connection.prepare("SELECT sq_variable_echo(?, ?, ?)", 1, 2, 3).query()
-
-            // Then
-            XCTAssertEqual(result1, 1)
-            XCTAssertEqual(result2, 1)
-            XCTAssertEqual(result3, 2)
-            XCTAssertEqual(result4, 3)
-
-            XCTAssertThrowsError(try connection.prepare("SELECT sq_echo(?, ?)", 1, 2))
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+        try connection.addScalarFunction(named: "sq_echo", argumentCount: 1) { _, _ in
+            return .integer(1)
         }
+
+        try connection.addScalarFunction(named: "sq_variable_echo", argumentCount: -1) { _, args in
+            return .integer(Int32(args.count))
+        }
+
+        // When
+        let result1: Int64? = try connection.prepare("SELECT sq_echo(?)", 1).query()
+        let result2: Int64? = try connection.prepare("SELECT sq_variable_echo(?)", 1).query()
+        let result3: Int64? = try connection.prepare("SELECT sq_variable_echo(?, ?)", 1, 2).query()
+        let result4: Int64? = try connection.prepare("SELECT sq_variable_echo(?, ?, ?)", 1, 2, 3).query()
+
+        // Then
+        XCTAssertEqual(result1, 1)
+        XCTAssertEqual(result2, 1)
+        XCTAssertEqual(result3, 2)
+        XCTAssertEqual(result4, 3)
+
+        XCTAssertThrowsError(try connection.prepare("SELECT sq_echo(?, ?)", 1, 2))
     }
 
     // MARK: - Aggregate Functions
 
-    func testThatAggregateFunctionCanSumIntegerValuesWithOneFunctionValue() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            try loadTablesAndDataForAggregateFunctions(using: connection)
+    func testThatAggregateFunctionCanSumIntegerValuesWithOneFunctionValue() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        try loadTablesAndDataForAggregateFunctions(using: connection)
 
-            try connection.addAggregateFunction(
-                named: "sq_sum",
-                argumentCount: 1,
-                contextObjectFactory: { return MutableNumber() },
-                stepFunction: { context, values in
-                    guard
-                        let value = values.first,
-                        let sumNumber = context.stepObject as? MutableNumber,
-                        value.type == .integer
+        try connection.addAggregateFunction(
+            named: "sq_sum",
+            argumentCount: 1,
+            contextObjectFactory: { return MutableNumber() },
+            stepFunction: { context, values in
+                guard
+                    let value = values.first,
+                    let sumNumber = context.stepObject as? MutableNumber,
+                    value.type == .integer
                     else { return }
 
-                    sumNumber.number += value.long
-                },
-                finalFunction: { context in
-                    guard let sumNumber = context.finalObject as? MutableNumber else { return .null }
-                    return .long(sumNumber.number)
-                }
-            )
-
-            // When
-            let sumResult: Int64? = try connection.prepare("SELECT sq_sum(value) FROM sq_values").query()
-
-            // Then
-            XCTAssertEqual(sumResult, 45)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
-    }
-
-    func testThatAggregateFunctionCanSumIntegerValuesWithOneFunctionValueAndGroupByClause() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            try loadTablesAndDataForAggregateFunctions(using: connection)
-
-            try connection.addAggregateFunction(
-                named: "sq_sum",
-                argumentCount: 1,
-                contextObjectFactory: { return MutableNumber() },
-                stepFunction: { context, values in
-                    guard
-                        let value = values.first,
-                        let sumNumber = context.stepObject as? MutableNumber,
-                        value.type == .integer
-                    else { return }
-
-                    sumNumber.number += value.long
-                },
-                finalFunction: { context in
-                    guard let sumNumber = context.finalObject as? MutableNumber else { return .null }
-                    return .long(sumNumber.number)
-                }
-            )
-
-            let sql = "SELECT sq_sum(value) FROM sq_values GROUP BY grp"
-
-            // When
-            let sumResults: [Int64?] = try connection.query(sql)
-
-            // Then
-            XCTAssertEqual(sumResults.count, 4)
-
-            if sumResults.count == 4 {
-                XCTAssertEqual(sumResults[0], 3)
-                XCTAssertEqual(sumResults[1], 7)
-                XCTAssertEqual(sumResults[2], 18)
-                XCTAssertEqual(sumResults[3], 17)
+                sumNumber.number += value.long
+            },
+            finalFunction: { context in
+                guard let sumNumber = context.finalObject as? MutableNumber else { return .null }
+                return .long(sumNumber.number)
             }
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        )
+
+        // When
+        let sumResult: Int64? = try connection.prepare("SELECT sq_sum(value) FROM sq_values").query()
+
+        // Then
+        XCTAssertEqual(sumResult, 45)
     }
 
-    func testThatAggregateFunctionCanSumIntegerValuesWithTwoFunctionValues() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            try loadTablesAndDataForAggregateFunctions(using: connection)
+    func testThatAggregateFunctionCanSumIntegerValuesWithOneFunctionValueAndGroupByClause() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        try loadTablesAndDataForAggregateFunctions(using: connection)
 
-            try connection.addAggregateFunction(
-                named: "sq_sum",
-                argumentCount: 2,
-                contextObjectFactory: { return MutableNumber() },
-                stepFunction: { context, values in
-                    guard
-                        values.count == 2,
-                        values.filter({ $0.type == .integer }).count == 2,
-                        let sumNumber = context.stepObject as? MutableNumber
+        try connection.addAggregateFunction(
+            named: "sq_sum",
+            argumentCount: 1,
+            contextObjectFactory: { return MutableNumber() },
+            stepFunction: { context, values in
+                guard
+                    let value = values.first,
+                    let sumNumber = context.stepObject as? MutableNumber,
+                    value.type == .integer
                     else { return }
 
-                    sumNumber.number += values.reduce(0) { $0 + $1.long }
-                },
-                finalFunction: { context in
-                    guard let sumNumber = context.finalObject as? MutableNumber else { return .null }
-                    return .long(sumNumber.number)
-                }
-            )
+                sumNumber.number += value.long
+            },
+            finalFunction: { context in
+                guard let sumNumber = context.finalObject as? MutableNumber else { return .null }
+                return .long(sumNumber.number)
+            }
+        )
 
-            // When
-            let sumResult: Int64? = try connection.prepare("SELECT sq_sum(grp, value) FROM sq_values").query()
+        let sql = "SELECT sq_sum(value) FROM sq_values GROUP BY grp"
 
-            // Then
-            XCTAssertEqual(sumResult, 59)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+        // When
+        let sumResults: [Int64?] = try connection.query(sql)
+
+        // Then
+        XCTAssertEqual(sumResults.count, 4)
+
+        if sumResults.count == 4 {
+            XCTAssertEqual(sumResults[0], 3)
+            XCTAssertEqual(sumResults[1], 7)
+            XCTAssertEqual(sumResults[2], 18)
+            XCTAssertEqual(sumResults[3], 17)
         }
     }
 
-    func testThatAggregateFunctionThrowsWhenCalledWithInvalidNumberOfArguments() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            try loadTablesAndDataForAggregateFunctions(using: connection)
+    func testThatAggregateFunctionCanSumIntegerValuesWithTwoFunctionValues() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        try loadTablesAndDataForAggregateFunctions(using: connection)
 
-            try connection.addAggregateFunction(
-                named: "sq_echo",
-                argumentCount: 1,
-                contextObjectFactory: { return MutableNumber() },
-                stepFunction: { _, _ in },
-                finalFunction: { _ in return .long(1) }
-            )
+        try connection.addAggregateFunction(
+            named: "sq_sum",
+            argumentCount: 2,
+            contextObjectFactory: { return MutableNumber() },
+            stepFunction: { context, values in
+                guard
+                    values.count == 2,
+                    values.filter({ $0.type == .integer }).count == 2,
+                    let sumNumber = context.stepObject as? MutableNumber
+                    else { return }
 
-            try connection.addAggregateFunction(
-                named: "sq_variable_echo",
-                argumentCount: -1,
-                contextObjectFactory: { return MutableNumber() },
-                stepFunction: { context, values in
-                    guard let sumNumber = context.stepObject as? MutableNumber else { return }
-                    sumNumber.number = Int64(values.count)
-                },
-                finalFunction: { context in
-                    guard let sumNumber = context.stepObject as? MutableNumber else { return .null }
-                    return .long(sumNumber.number)
-                }
-            )
+                sumNumber.number += values.reduce(0) { $0 + $1.long }
+            },
+            finalFunction: { context in
+                guard let sumNumber = context.finalObject as? MutableNumber else { return .null }
+                return .long(sumNumber.number)
+            }
+        )
 
-            // When
-            let result1: Int64? = try connection.prepare("SELECT sq_echo(grp) FROM sq_values").query()
-            let result2: Int64? = try connection.prepare("SELECT sq_variable_echo(grp) FROM sq_values").query()
-            let result3: Int64? = try connection.prepare("SELECT sq_variable_echo(grp, value) FROM sq_values").query()
-            let result4: Int64? = try connection.prepare("SELECT sq_variable_echo(grp, value, grp) FROM sq_values").query()
+        // When
+        let sumResult: Int64? = try connection.prepare("SELECT sq_sum(grp, value) FROM sq_values").query()
 
-            // Then
-            XCTAssertEqual(result1, 1)
-            XCTAssertEqual(result2, 1)
-            XCTAssertEqual(result3, 2)
-            XCTAssertEqual(result4, 3)
+        // Then
+        XCTAssertEqual(sumResult, 59)
+    }
 
-            XCTAssertThrowsError(try connection.prepare("SELECT sq_echo(grp, value) FROM sq_values"))
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+    func testThatAggregateFunctionThrowsWhenCalledWithInvalidNumberOfArguments() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        try loadTablesAndDataForAggregateFunctions(using: connection)
+
+        try connection.addAggregateFunction(
+            named: "sq_echo",
+            argumentCount: 1,
+            contextObjectFactory: { return MutableNumber() },
+            stepFunction: { _, _ in },
+            finalFunction: { _ in return .long(1) }
+        )
+
+        try connection.addAggregateFunction(
+            named: "sq_variable_echo",
+            argumentCount: -1,
+            contextObjectFactory: { return MutableNumber() },
+            stepFunction: { context, values in
+                guard let sumNumber = context.stepObject as? MutableNumber else { return }
+                sumNumber.number = Int64(values.count)
+            },
+            finalFunction: { context in
+                guard let sumNumber = context.stepObject as? MutableNumber else { return .null }
+                return .long(sumNumber.number)
+            }
+        )
+
+        // When
+        let result1: Int64? = try connection.prepare("SELECT sq_echo(grp) FROM sq_values").query()
+        let result2: Int64? = try connection.prepare("SELECT sq_variable_echo(grp) FROM sq_values").query()
+        let result3: Int64? = try connection.prepare("SELECT sq_variable_echo(grp, value) FROM sq_values").query()
+        let result4: Int64? = try connection.prepare("SELECT sq_variable_echo(grp, value, grp) FROM sq_values").query()
+
+        // Then
+        XCTAssertEqual(result1, 1)
+        XCTAssertEqual(result2, 1)
+        XCTAssertEqual(result3, 2)
+        XCTAssertEqual(result4, 3)
+
+        XCTAssertThrowsError(try connection.prepare("SELECT sq_echo(grp, value) FROM sq_values"))
     }
 
     // MARK: - Private - Table Data Helpers

--- a/Tests/Tests/Connection/Functions/QueryTests.swift
+++ b/Tests/Tests/Connection/Functions/QueryTests.swift
@@ -38,226 +38,190 @@ class QueryTestCase: BaseConnectionTestCase {
 
     // MARK: - Tests - Query APIs
 
-    func testThatConnectionCanQueryExtractable() {
-        do {
-            // Given, When
-            let totalMissions: Int? = try connection.query("SELECT sum(missions) FROM agents")
-            let name: String? = try connection.query("SELECT name FROM agents WHERE car = ?", "Charger")
-            let salary: Double? = try connection.query("SELECT salary FROM agents WHERE car = ?", ["Charger"])
-            let id: Int? = try connection.query("SELECT id FROM agents WHERE car = :car", [":car": "Charger"])
-            let car: String? = try connection.query("SELECT car FROM agents WHERE name = ?", "Lana Kane")
+    func testThatConnectionCanQueryExtractable() throws {
+        // Given, When
+        let totalMissions: Int? = try connection.query("SELECT sum(missions) FROM agents")
+        let name: String? = try connection.query("SELECT name FROM agents WHERE car = ?", "Charger")
+        let salary: Double? = try connection.query("SELECT salary FROM agents WHERE car = ?", ["Charger"])
+        let id: Int? = try connection.query("SELECT id FROM agents WHERE car = :car", [":car": "Charger"])
+        let car: String? = try connection.query("SELECT car FROM agents WHERE name = ?", "Lana Kane")
 
-            // Then
-            XCTAssertEqual(totalMissions, 2_800)
-            XCTAssertEqual(name, "Sterling Archer")
-            XCTAssertEqual(salary, 2_500_000.56)
-            XCTAssertEqual(id, 1)
-            XCTAssertEqual(car, nil)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(totalMissions, 2_800)
+        XCTAssertEqual(name, "Sterling Archer")
+        XCTAssertEqual(salary, 2_500_000.56)
+        XCTAssertEqual(id, 1)
+        XCTAssertEqual(car, nil)
     }
 
-    func testThatConnectionCanQueryRow() {
-        do {
-            // Given, When
-            let row1: Row? = try connection.query("SELECT name FROM agents WHERE car IS NULL")
-            let row2: Row? = try connection.query("SELECT id, name, missions FROM agents WHERE car = ?", "Charger")
-            let row3: Row? = try connection.query("SELECT salary FROM agents WHERE car = ?", ["Charger"])
-            let row4: Row? = try connection.query("SELECT * FROM agents WHERE car = :car", [":car": "Charger"])
+    func testThatConnectionCanQueryRow() throws {
+        // Given, When
+        let row1: Row? = try connection.query("SELECT name FROM agents WHERE car IS NULL")
+        let row2: Row? = try connection.query("SELECT id, name, missions FROM agents WHERE car = ?", "Charger")
+        let row3: Row? = try connection.query("SELECT salary FROM agents WHERE car = ?", ["Charger"])
+        let row4: Row? = try connection.query("SELECT * FROM agents WHERE car = :car", [":car": "Charger"])
 
-            // Then
-            XCTAssertEqual(row1?.columnCount, 1)
-            XCTAssertEqual(row1?.columns.count, 1)
+        // Then
+        XCTAssertEqual(row1?.columnCount, 1)
+        XCTAssertEqual(row1?.columns.count, 1)
 
-            XCTAssertEqual(row2?.columnCount, 3)
-            XCTAssertEqual(row2?.columns.count, 3)
+        XCTAssertEqual(row2?.columnCount, 3)
+        XCTAssertEqual(row2?.columns.count, 3)
 
-            XCTAssertEqual(row3?.columnCount, 1)
-            XCTAssertEqual(row3?.columns.count, 1)
+        XCTAssertEqual(row3?.columnCount, 1)
+        XCTAssertEqual(row3?.columns.count, 1)
 
-            XCTAssertEqual(row4?.columnCount, 7)
-            XCTAssertEqual(row4?.columns.count, 7)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        XCTAssertEqual(row4?.columnCount, 7)
+        XCTAssertEqual(row4?.columns.count, 7)
     }
 
-    func testThatConnectionCanQueryExpressibleByRow() {
-        do {
-            // Given, When
-            let lana1: Agent? = try connection.query("SELECT * FROM agents WHERE car IS NULL")
-            let archer1: Agent? = try connection.query("SELECT * FROM agents WHERE car = ?", "Charger")
-            let archer2: Agent? = try connection.query("SELECT * FROM agents WHERE car = ?", ["Charger"])
-            let archer3: Agent? = try connection.query("SELECT * FROM agents WHERE car = :car", [":car": "Charger"])
+    func testThatConnectionCanQueryExpressibleByRow() throws {
+        // Given, When
+        let lana1: Agent? = try connection.query("SELECT * FROM agents WHERE car IS NULL")
+        let archer1: Agent? = try connection.query("SELECT * FROM agents WHERE car = ?", "Charger")
+        let archer2: Agent? = try connection.query("SELECT * FROM agents WHERE car = ?", ["Charger"])
+        let archer3: Agent? = try connection.query("SELECT * FROM agents WHERE car = :car", [":car": "Charger"])
 
-            // Then
-            XCTAssertEqual(lana1, lana)
-            XCTAssertEqual(archer1, archer)
-            XCTAssertEqual(archer2, archer)
-            XCTAssertEqual(archer3, archer)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(lana1, lana)
+        XCTAssertEqual(archer1, archer)
+        XCTAssertEqual(archer2, archer)
+        XCTAssertEqual(archer3, archer)
     }
 
-    func testThatConnectionCanQueryT() {
-        do {
-            // Given
-            let sql1 = "SELECT * FROM agents WHERE car = ?"
-            let sql2 = "SELECT * FROM agents WHERE car = :car"
+    func testThatConnectionCanQueryT() throws {
+        // Given
+        let sql1 = "SELECT * FROM agents WHERE car = ?"
+        let sql2 = "SELECT * FROM agents WHERE car = :car"
 
-            // When
-            let lana1: Agent? = try connection.query("SELECT * FROM agents WHERE car IS NULL") { try Agent(row: $0) }
-            let archer1: Agent? = try connection.query(sql1, "Charger") { try Agent(row: $0) }
-            let archer2: Agent? = try connection.query(sql1, ["Charger"]) { try Agent(row: $0) }
-            let archer3: Agent? = try connection.query(sql2, [":car": "Charger"]) { try Agent(row: $0) }
+        // When
+        let lana1: Agent? = try connection.query("SELECT * FROM agents WHERE car IS NULL") { try Agent(row: $0) }
+        let archer1: Agent? = try connection.query(sql1, "Charger") { try Agent(row: $0) }
+        let archer2: Agent? = try connection.query(sql1, ["Charger"]) { try Agent(row: $0) }
+        let archer3: Agent? = try connection.query(sql2, [":car": "Charger"]) { try Agent(row: $0) }
 
-            // Then
-            XCTAssertEqual(lana1, lana)
-            XCTAssertEqual(archer1, archer)
-            XCTAssertEqual(archer2, archer)
-            XCTAssertEqual(archer3, archer)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(lana1, lana)
+        XCTAssertEqual(archer1, archer)
+        XCTAssertEqual(archer2, archer)
+        XCTAssertEqual(archer3, archer)
     }
 
-    func testThatConnectionCanQueryExtractableArray() {
-        do {
-            // Given, When
-            let ids: [Int] = try connection.query("SELECT id FROM agents")
-            let names: [String] = try connection.query("SELECT name FROM agents WHERE car IS NULL OR car != ?", "Honda")
-            let salaries: [Double] = try connection.query("SELECT salary FROM agents WHERE salary > ?", [100_000])
-            let cars: [String] = try connection.query("SELECT car FROM agents WHERE car IS NULL OR car != :car", [":car": "Honda"])
+    func testThatConnectionCanQueryExtractableArray() throws {
+        // Given, When
+        let ids: [Int] = try connection.query("SELECT id FROM agents")
+        let names: [String] = try connection.query("SELECT name FROM agents WHERE car IS NULL OR car != ?", "Honda")
+        let salaries: [Double] = try connection.query("SELECT salary FROM agents WHERE salary > ?", [100_000])
+        let cars: [String] = try connection.query("SELECT car FROM agents WHERE car IS NULL OR car != :car", [":car": "Honda"])
 
-            // Then
-            XCTAssertEqual(ids, [1, 2])
-            XCTAssertEqual(names, ["Sterling Archer", "Lana Kane"])
-            XCTAssertEqual(salaries, [2_500_000.56, 9_600_200.11])
-            XCTAssertEqual(cars, ["Charger"])
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(ids, [1, 2])
+        XCTAssertEqual(names, ["Sterling Archer", "Lana Kane"])
+        XCTAssertEqual(salaries, [2_500_000.56, 9_600_200.11])
+        XCTAssertEqual(cars, ["Charger"])
     }
 
-    func testThatConnectionCanQueryExpressibleByRowArray() {
-        do {
-            // Given, When
-            let agents1: [Agent] = try connection.query("SELECT * FROM agents")
-            let agents2: [Agent] = try connection.query("SELECT * FROM agents WHERE missions > ?", 500)
-            let agents3: [Agent] = try connection.query("SELECT * FROM agents WHERE missions > ?", [1])
-            let agents4: [Agent] = try connection.query("SELECT * FROM agents WHERE missions < :missions", [":missions": 2000])
+    func testThatConnectionCanQueryExpressibleByRowArray() throws {
+        // Given, When
+        let agents1: [Agent] = try connection.query("SELECT * FROM agents")
+        let agents2: [Agent] = try connection.query("SELECT * FROM agents WHERE missions > ?", 500)
+        let agents3: [Agent] = try connection.query("SELECT * FROM agents WHERE missions > ?", [1])
+        let agents4: [Agent] = try connection.query("SELECT * FROM agents WHERE missions < :missions", [":missions": 2000])
 
-            // Then
-            XCTAssertEqual(agents1, [archer, lana])
-            XCTAssertEqual(agents2, [lana])
-            XCTAssertEqual(agents3, [archer, lana])
-            XCTAssertEqual(agents4, [archer])
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(agents1, [archer, lana])
+        XCTAssertEqual(agents2, [lana])
+        XCTAssertEqual(agents3, [archer, lana])
+        XCTAssertEqual(agents4, [archer])
     }
 
-    func testThatConnectionCanQueryTArray() {
-        do {
-            // Given
-            let sql1 = "SELECT * FROM agents WHERE car = ?"
-            let sql2 = "SELECT * FROM agents WHERE car = :car"
+    func testThatConnectionCanQueryTArray() throws {
+        // Given
+        let sql1 = "SELECT * FROM agents WHERE car = ?"
+        let sql2 = "SELECT * FROM agents WHERE car = :car"
 
-            // When
-            let agents1: [Agent] = try connection.query("SELECT * FROM agents") { try Agent(row: $0) }
-            let agents2: [Agent] = try connection.query(sql1, "Charger") { try Agent(row: $0) }
-            let agents3: [Agent] = try connection.query(sql1, ["Charger"]) { try Agent(row: $0) }
-            let agents4: [Agent] = try connection.query(sql2, [":car": "Charger"]) { try Agent(row: $0) }
+        // When
+        let agents1: [Agent] = try connection.query("SELECT * FROM agents") { try Agent(row: $0) }
+        let agents2: [Agent] = try connection.query(sql1, "Charger") { try Agent(row: $0) }
+        let agents3: [Agent] = try connection.query(sql1, ["Charger"]) { try Agent(row: $0) }
+        let agents4: [Agent] = try connection.query(sql2, [":car": "Charger"]) { try Agent(row: $0) }
 
-            // Then
-            XCTAssertEqual(agents1, [archer, lana])
-            XCTAssertEqual(agents2, [archer])
-            XCTAssertEqual(agents3, [archer])
-            XCTAssertEqual(agents4, [archer])
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(agents1, [archer, lana])
+        XCTAssertEqual(agents2, [archer])
+        XCTAssertEqual(agents3, [archer])
+        XCTAssertEqual(agents4, [archer])
     }
 
-    func testThatConnectionCanQueryDictionary() {
-        do {
-            // Given
-            let sql1 = "SELECT name, missions FROM agents WHERE missions > ?"
-            let sql2 = "SELECT name, missions FROM agents WHERE missions > :missions"
+    func testThatConnectionCanQueryDictionary() throws {
+        // Given
+        let sql1 = "SELECT name, missions FROM agents WHERE missions > ?"
+        let sql2 = "SELECT name, missions FROM agents WHERE missions > :missions"
 
-            // When
-            let cars: [String: String?] = try connection.query("SELECT name, car FROM agents") { ($0[0], $0[1]) }
-            let missions1: [String: Int] = try connection.query(sql1, 10) { ($0[0], $0[1]) }
-            let missions2: [String: Int] = try connection.query(sql1, [10]) { ($0[0], $0[1]) }
-            let missions3: [String: Int] = try connection.query(sql2, [":missions": 10]) { ($0[0], $0[1]) }
+        // When
+        let cars: [String: String?] = try connection.query("SELECT name, car FROM agents") { ($0[0], $0[1]) }
+        let missions1: [String: Int] = try connection.query(sql1, 10) { ($0[0], $0[1]) }
+        let missions2: [String: Int] = try connection.query(sql1, [10]) { ($0[0], $0[1]) }
+        let missions3: [String: Int] = try connection.query(sql2, [":missions": 10]) { ($0[0], $0[1]) }
 
-            // Then
-            XCTAssertEqual(cars.count, 2)
-            XCTAssertEqual(cars["Sterling Archer"] as? String, "Charger")
-            XCTAssertEqual(cars["Lana Kane"] as? String, nil)
+        // Then
+        XCTAssertEqual(cars.count, 2)
+        XCTAssertEqual(cars["Sterling Archer"] as? String, "Charger")
+        XCTAssertEqual(cars["Lana Kane"] as? String, nil)
 
-            XCTAssertEqual(missions1.count, 2)
-            XCTAssertEqual(missions1["Sterling Archer"], 485)
-            XCTAssertEqual(missions1["Lana Kane"], 2_315)
+        XCTAssertEqual(missions1.count, 2)
+        XCTAssertEqual(missions1["Sterling Archer"], 485)
+        XCTAssertEqual(missions1["Lana Kane"], 2_315)
 
-            XCTAssertEqual(missions2.count, 2)
-            XCTAssertEqual(missions2["Sterling Archer"], 485)
-            XCTAssertEqual(missions2["Lana Kane"], 2_315)
+        XCTAssertEqual(missions2.count, 2)
+        XCTAssertEqual(missions2["Sterling Archer"], 485)
+        XCTAssertEqual(missions2["Lana Kane"], 2_315)
 
-            XCTAssertEqual(missions3.count, 2)
-            XCTAssertEqual(missions3["Sterling Archer"], 485)
-            XCTAssertEqual(missions3["Lana Kane"], 2_315)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        XCTAssertEqual(missions3.count, 2)
+        XCTAssertEqual(missions3["Sterling Archer"], 485)
+        XCTAssertEqual(missions3["Lana Kane"], 2_315)
     }
 
-    func testThatConnectionCanQueryDictionaryWithResultInjection() {
-        do {
-            // Given
-            let sql1 = "SELECT name, missions FROM agents"
-            let sql2 = "SELECT name, missions FROM agents WHERE missions > ?"
-            let sql3 = "SELECT name, missions FROM agents WHERE missions > :missions"
+    func testThatConnectionCanQueryDictionaryWithResultInjection() throws {
+        // Given
+        let sql1 = "SELECT name, missions FROM agents"
+        let sql2 = "SELECT name, missions FROM agents WHERE missions > ?"
+        let sql3 = "SELECT name, missions FROM agents WHERE missions > :missions"
 
-            // When
-            let missions1: [Int: [String: Int]] = try connection.query(sql1) { results, row in
-                var result = results[1] ?? [:]
-                result[row[0]] = row[1]
-                return (1, result)
+        // When
+        let missions1: [Int: [String: Int]] = try connection.query(sql1) { results, row in
+            var result = results[1] ?? [:]
+            result[row[0]] = row[1]
+            return (1, result)
+        }
+
+        let missions2: [Int: [String: Int]] = try connection.query(sql2, 10) { results, row in
+            var result = results[1] ?? [:]
+            result[row[0]] = row[1]
+            return (1, result)
+        }
+
+        let missions3: [Int: [String: Int]] = try connection.query(sql2, [10]) { results, row in
+            var result = results[1] ?? [:]
+            result[row[0]] = row[1]
+            return (1, result)
+        }
+
+        let missions4: [Int: [String: Int]] = try connection.query(sql3, [":missions": 10]) { results, row in
+            var result = results[1] ?? [:]
+            result[row[0]] = row[1]
+            return (1, result)
+        }
+
+        // Then
+        for missions in [missions1, missions2, missions3, missions4] {
+            XCTAssertEqual(missions.count, 1)
+
+            if missions.count == 1 {
+                XCTAssertEqual(missions[1]?.count, 2)
+                XCTAssertEqual(missions[1]?["Sterling Archer"], 485)
+                XCTAssertEqual(missions[1]?["Lana Kane"], 2_315)
             }
-
-            let missions2: [Int: [String: Int]] = try connection.query(sql2, 10) { results, row in
-                var result = results[1] ?? [:]
-                result[row[0]] = row[1]
-                return (1, result)
-            }
-
-            let missions3: [Int: [String: Int]] = try connection.query(sql2, [10]) { results, row in
-                var result = results[1] ?? [:]
-                result[row[0]] = row[1]
-                return (1, result)
-            }
-
-            let missions4: [Int: [String: Int]] = try connection.query(sql3, [":missions": 10]) { results, row in
-                var result = results[1] ?? [:]
-                result[row[0]] = row[1]
-                return (1, result)
-            }
-
-            // Then
-            for missions in [missions1, missions2, missions3, missions4] {
-                XCTAssertEqual(missions.count, 1)
-
-                if missions.count == 1 {
-                    XCTAssertEqual(missions[1]?.count, 2)
-                    XCTAssertEqual(missions[1]?["Sterling Archer"], 485)
-                    XCTAssertEqual(missions[1]?["Lana Kane"], 2_315)
-                }
-            }
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
         }
     }
 }

--- a/Tests/Tests/Connection/Functions/TraceTests.swift
+++ b/Tests/Tests/Connection/Functions/TraceTests.swift
@@ -13,162 +13,150 @@ import Foundation
 import XCTest
 
 class TraceTestCase: BaseTestCase {
-    func testThatConnectionCanTraceStatementExecution() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
+    func testThatConnectionCanTraceStatementExecution() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
 
-            var statements: [String] = []
+        var statements: [String] = []
+
+        // When
+        connection.trace { SQL in
+            statements.append(SQL)
+        }
+
+        try connection.execute("CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT)")
+        try connection.prepare("INSERT INTO agents VALUES(?, ?)").bind(1, "Sterling Archer").run()
+        try connection.prepare("INSERT INTO agents VALUES(?, ?)").bind(2, "Lana Kane").run()
+        try connection.stepAll("SELECT * FROM agents")
+
+        connection.trace(nil)
+
+        // Then
+        if statements.count == 4 {
+            XCTAssertEqual(statements[0], "CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT)")
+            XCTAssertEqual(statements[1], "INSERT INTO agents VALUES(1, 'Sterling Archer')")
+            XCTAssertEqual(statements[2], "INSERT INTO agents VALUES(2, 'Lana Kane')")
+            XCTAssertEqual(statements[3], "SELECT * FROM agents")
+        } else {
+            XCTFail("statements count should be 4")
+        }
+    }
+
+    func testThatConnectionCanTraceStatementEventExecution() throws {
+        if #available(iOS 10.0, macOS 10.12.0, tvOS 10.0, watchOS 3.0, *) {
+            // Given
+            var connection: Connection? = try Connection(storageLocation: storageLocation)
+
+            let mask = (
+                Connection.TraceEvent.statementMask |
+                Connection.TraceEvent.profileMask |
+                Connection.TraceEvent.rowMask |
+                Connection.TraceEvent.connectionClosedMask
+            )
+
+            var traceEvents: [Connection.TraceEvent] = []
 
             // When
-            connection.trace { SQL in
-                statements.append(SQL)
+            connection?.traceEvent(mask: mask) { event in
+                traceEvents.append(event)
             }
 
-            try connection.execute("CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT)")
-            try connection.prepare("INSERT INTO agents VALUES(?, ?)").bind(1, "Sterling Archer").run()
-            try connection.prepare("INSERT INTO agents VALUES(?, ?)").bind(2, "Lana Kane").run()
-            try connection.stepAll("SELECT * FROM agents")
+            try connection?.execute("CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT)")
+            try connection?.prepare("INSERT INTO agents VALUES(?, ?)").bind(1, "Sterling Archer").run()
+            try connection?.prepare("INSERT INTO agents VALUES(?, ?)").bind(2, "Lana Kane").run()
+            try connection?.stepAll("SELECT * FROM agents")
 
-            connection.trace(nil)
+            connection = nil
 
             // Then
-            if statements.count == 4 {
-                XCTAssertEqual(statements[0], "CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT)")
-                XCTAssertEqual(statements[1], "INSERT INTO agents VALUES(1, 'Sterling Archer')")
-                XCTAssertEqual(statements[2], "INSERT INTO agents VALUES(2, 'Lana Kane')")
-                XCTAssertEqual(statements[3], "SELECT * FROM agents")
+            if traceEvents.count == 11 {
+                XCTAssertEqual(traceEvents[0].rawValue, "Statement")
+                XCTAssertEqual(traceEvents[1].rawValue, "Profile")
+                XCTAssertEqual(traceEvents[2].rawValue, "Statement")
+                XCTAssertEqual(traceEvents[3].rawValue, "Profile")
+                XCTAssertEqual(traceEvents[4].rawValue, "Statement")
+                XCTAssertEqual(traceEvents[5].rawValue, "Profile")
+                XCTAssertEqual(traceEvents[6].rawValue, "Statement")
+                XCTAssertEqual(traceEvents[7].rawValue, "Row")
+                XCTAssertEqual(traceEvents[8].rawValue, "Row")
+                XCTAssertEqual(traceEvents[9].rawValue, "Profile")
+                XCTAssertEqual(traceEvents[10].rawValue, "ConnectionClosed")
+
+                if case let .statement(statement, sql) = traceEvents[0] {
+                    XCTAssertEqual(statement, "CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT)")
+                    XCTAssertEqual(sql, "CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT)")
+                }
+
+                if case let .profile(statement, seconds) = traceEvents[1] {
+                    XCTAssertEqual(statement, "CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT)")
+                    XCTAssertGreaterThanOrEqual(seconds, 0.0)
+                }
+
+                if case let .statement(statement, sql) = traceEvents[2] {
+                    XCTAssertEqual(statement, "INSERT INTO agents VALUES(1, \'Sterling Archer\')")
+                    XCTAssertEqual(sql, "INSERT INTO agents VALUES(?, ?)")
+                }
+
+                if case let .profile(statement, seconds) = traceEvents[3] {
+                    XCTAssertEqual(statement, "INSERT INTO agents VALUES(1, \'Sterling Archer\')")
+                    XCTAssertGreaterThanOrEqual(seconds, 0.0)
+                }
+
+                if case let .statement(statement, sql) = traceEvents[4] {
+                    XCTAssertEqual(statement, "INSERT INTO agents VALUES(2, \'Lana Kane\')")
+                    XCTAssertEqual(sql, "INSERT INTO agents VALUES(?, ?)")
+                }
+
+                if case let .profile(statement, seconds) = traceEvents[5] {
+                    XCTAssertEqual(statement, "INSERT INTO agents VALUES(2, \'Lana Kane\')")
+                    XCTAssertGreaterThanOrEqual(seconds, 0.0)
+                }
+
+                if case let .statement(statement, sql) = traceEvents[6] {
+                    XCTAssertEqual(statement, "SELECT * FROM agents")
+                    XCTAssertEqual(sql, "SELECT * FROM agents")
+                }
+
+                if case let .row(statement) = traceEvents[7] {
+                    XCTAssertEqual(statement, "SELECT * FROM agents")
+                }
+
+                if case let .row(statement) = traceEvents[8] {
+                    XCTAssertEqual(statement, "SELECT * FROM agents")
+                }
+
+                if case let .profile(statement, seconds) = traceEvents[9] {
+                    XCTAssertEqual(statement, "SELECT * FROM agents")
+                    XCTAssertGreaterThanOrEqual(seconds, 0.0)
+                }
             } else {
-                XCTFail("statements count should be 4")
-            }
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
-    }
-
-    func testThatConnectionCanTraceStatementEventExecution() {
-        if #available(iOS 10.0, macOS 10.12.0, tvOS 10.0, watchOS 3.0, *) {
-            do {
-                // Given
-                var connection: Connection? = try Connection(storageLocation: storageLocation)
-
-                let mask = (
-                    Connection.TraceEvent.statementMask |
-                    Connection.TraceEvent.profileMask |
-                    Connection.TraceEvent.rowMask |
-                    Connection.TraceEvent.connectionClosedMask
-                )
-
-                var traceEvents: [Connection.TraceEvent] = []
-
-                // When
-                connection?.traceEvent(mask: mask) { event in
-                    traceEvents.append(event)
-                }
-
-                try connection?.execute("CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT)")
-                try connection?.prepare("INSERT INTO agents VALUES(?, ?)").bind(1, "Sterling Archer").run()
-                try connection?.prepare("INSERT INTO agents VALUES(?, ?)").bind(2, "Lana Kane").run()
-                try connection?.stepAll("SELECT * FROM agents")
-
-                connection = nil
-
-                // Then
-                if traceEvents.count == 11 {
-                    XCTAssertEqual(traceEvents[0].rawValue, "Statement")
-                    XCTAssertEqual(traceEvents[1].rawValue, "Profile")
-                    XCTAssertEqual(traceEvents[2].rawValue, "Statement")
-                    XCTAssertEqual(traceEvents[3].rawValue, "Profile")
-                    XCTAssertEqual(traceEvents[4].rawValue, "Statement")
-                    XCTAssertEqual(traceEvents[5].rawValue, "Profile")
-                    XCTAssertEqual(traceEvents[6].rawValue, "Statement")
-                    XCTAssertEqual(traceEvents[7].rawValue, "Row")
-                    XCTAssertEqual(traceEvents[8].rawValue, "Row")
-                    XCTAssertEqual(traceEvents[9].rawValue, "Profile")
-                    XCTAssertEqual(traceEvents[10].rawValue, "ConnectionClosed")
-
-                    if case let .statement(statement, sql) = traceEvents[0] {
-                        XCTAssertEqual(statement, "CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT)")
-                        XCTAssertEqual(sql, "CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT)")
-                    }
-
-                    if case let .profile(statement, seconds) = traceEvents[1] {
-                        XCTAssertEqual(statement, "CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT)")
-                        XCTAssertGreaterThanOrEqual(seconds, 0.0)
-                    }
-
-                    if case let .statement(statement, sql) = traceEvents[2] {
-                        XCTAssertEqual(statement, "INSERT INTO agents VALUES(1, \'Sterling Archer\')")
-                        XCTAssertEqual(sql, "INSERT INTO agents VALUES(?, ?)")
-                    }
-
-                    if case let .profile(statement, seconds) = traceEvents[3] {
-                        XCTAssertEqual(statement, "INSERT INTO agents VALUES(1, \'Sterling Archer\')")
-                        XCTAssertGreaterThanOrEqual(seconds, 0.0)
-                    }
-
-                    if case let .statement(statement, sql) = traceEvents[4] {
-                        XCTAssertEqual(statement, "INSERT INTO agents VALUES(2, \'Lana Kane\')")
-                        XCTAssertEqual(sql, "INSERT INTO agents VALUES(?, ?)")
-                    }
-
-                    if case let .profile(statement, seconds) = traceEvents[5] {
-                        XCTAssertEqual(statement, "INSERT INTO agents VALUES(2, \'Lana Kane\')")
-                        XCTAssertGreaterThanOrEqual(seconds, 0.0)
-                    }
-
-                    if case let .statement(statement, sql) = traceEvents[6] {
-                        XCTAssertEqual(statement, "SELECT * FROM agents")
-                        XCTAssertEqual(sql, "SELECT * FROM agents")
-                    }
-
-                    if case let .row(statement) = traceEvents[7] {
-                        XCTAssertEqual(statement, "SELECT * FROM agents")
-                    }
-
-                    if case let .row(statement) = traceEvents[8] {
-                        XCTAssertEqual(statement, "SELECT * FROM agents")
-                    }
-
-                    if case let .profile(statement, seconds) = traceEvents[9] {
-                        XCTAssertEqual(statement, "SELECT * FROM agents")
-                        XCTAssertGreaterThanOrEqual(seconds, 0.0)
-                    }
-                } else {
-                    XCTFail("traceEvents count should be 11")
-                }
-            } catch {
-                XCTFail("Test encountered unexpected error: \(error)")
+                XCTFail("traceEvents count should be 11")
             }
         }
     }
 
-    func testThatConnectionCanTraceStatementEventExecutionUsingMask() {
+    func testThatConnectionCanTraceStatementEventExecutionUsingMask() throws {
         if #available(iOS 10.0, macOS 10.12.0, tvOS 10.0, watchOS 3.0, *) {
-            do {
-                // Given
-                var connection: Connection? = try Connection(storageLocation: storageLocation)
-                var traceEvents: [Connection.TraceEvent] = []
+            // Given
+            var connection: Connection? = try Connection(storageLocation: storageLocation)
+            var traceEvents: [Connection.TraceEvent] = []
 
-                let mask = Connection.TraceEvent.statementMask | Connection.TraceEvent.profileMask
+            let mask = Connection.TraceEvent.statementMask | Connection.TraceEvent.profileMask
 
-                // When
-                connection?.traceEvent(mask: mask) { event in
-                    traceEvents.append(event)
-                }
-
-                try connection?.execute("CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT)")
-                try connection?.prepare("INSERT INTO agents VALUES(?, ?)").bind(1, "Sterling Archer").run()
-                try connection?.prepare("INSERT INTO agents VALUES(?, ?)").bind(2, "Lana Kane").run()
-                try connection?.stepAll("SELECT * FROM agents")
-
-                connection = nil
-
-                // Then
-                XCTAssertEqual(traceEvents.count, 8)
-            } catch {
-                XCTFail("Test encountered unexpected error: \(error)")
+            // When
+            connection?.traceEvent(mask: mask) { event in
+                traceEvents.append(event)
             }
+
+            try connection?.execute("CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT)")
+            try connection?.prepare("INSERT INTO agents VALUES(?, ?)").bind(1, "Sterling Archer").run()
+            try connection?.prepare("INSERT INTO agents VALUES(?, ?)").bind(2, "Lana Kane").run()
+            try connection?.stepAll("SELECT * FROM agents")
+
+            connection = nil
+
+            // Then
+            XCTAssertEqual(traceEvents.count, 8)
         }
     }
 }

--- a/Tests/Tests/Connection/Functions/TransactionTests.swift
+++ b/Tests/Tests/Connection/Functions/TransactionTests.swift
@@ -13,151 +13,131 @@ import SQift
 import XCTest
 
 class TransactionTestCase: BaseConnectionTestCase {
-    func testThatConnectionCanExecuteTransaction() {
-        do {
-            // Given
-            try connection.execute("CREATE TABLE cars(id INTEGER PRIMARY KEY, name TEXT, price INTEGER)")
+    func testThatConnectionCanExecuteTransaction() throws {
+        // Given
+        try connection.execute("CREATE TABLE cars(id INTEGER PRIMARY KEY, name TEXT, price INTEGER)")
 
-            // When
-            try connection.transaction {
-                try connection.prepare("INSERT INTO cars VALUES(?, ?, ?)").bind(1, "Audi", 52642).run()
-                try connection.prepare("INSERT INTO cars VALUES(?, ?, ?)").bind(2, "Mercedes", 57127).run()
-            }
+        // When
+        try connection.transaction {
+            try connection.prepare("INSERT INTO cars VALUES(?, ?, ?)").bind(1, "Audi", 52642).run()
+            try connection.prepare("INSERT INTO cars VALUES(?, ?, ?)").bind(2, "Mercedes", 57127).run()
+        }
 
-            let rows: [[Any?]] = try connection.query("SELECT * FROM cars") { $0.values }
+        let rows: [[Any?]] = try connection.query("SELECT * FROM cars") { $0.values }
 
-            // Then
-            if rows.count == 2 {
-                XCTAssertEqual(rows[0][0] as? Int64, 1, "rows[0][0] should be 1")
-                XCTAssertEqual(rows[0][1] as? String, "Audi", "rows[0][1] should be `Audi`")
-                XCTAssertEqual(rows[0][2] as? Int64, 52642, "rows[0][2] should be 52642")
+        // Then
+        if rows.count == 2 {
+            XCTAssertEqual(rows[0][0] as? Int64, 1)
+            XCTAssertEqual(rows[0][1] as? String, "Audi")
+            XCTAssertEqual(rows[0][2] as? Int64, 52642)
 
-                XCTAssertEqual(rows[1][0] as? Int64, 2, "rows[1][0] should be 2")
-                XCTAssertEqual(rows[1][1] as? String, "Mercedes", "rows[1][1] should be `Mercedes`")
-                XCTAssertEqual(rows[1][2] as? Int64, 57127, "rows[1][2] should be 57127")
-            } else {
-                XCTFail("rows count should be 2")
-            }
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+            XCTAssertEqual(rows[1][0] as? Int64, 2)
+            XCTAssertEqual(rows[1][1] as? String, "Mercedes")
+            XCTAssertEqual(rows[1][2] as? Int64, 57127)
+        } else {
+            XCTFail("rows count should be 2")
         }
     }
 
-    func testThatConnectionCanRollbackTransactionExecutionWhenTransactionThrows() {
+    func testThatConnectionCanRollbackTransactionExecutionWhenTransactionThrows() throws {
+        // Given
+        try connection.execute("CREATE TABLE cars(id INTEGER PRIMARY KEY, name TEXT, price INTEGER)")
+
+        // When
         do {
-            // Given
-            try connection.execute("CREATE TABLE cars(id INTEGER PRIMARY KEY, name TEXT, price INTEGER)")
-
-            // When
-            do {
-                try connection.transaction {
-                    try connection.prepare("INSERT INTO cars VALUES(?, ?, ?)").bind(1, "Audi", 52642).run()
-                    try connection.prepare("INSERT IN cars VALUES(?, ?, ?)").bind(2, "Mercedes", 57127).run()
-                }
-            } catch {
-                // No-op: this is expected due to invalid SQL in second prepare statement
+            try connection.transaction {
+                try connection.prepare("INSERT INTO cars VALUES(?, ?, ?)").bind(1, "Audi", 52642).run()
+                try connection.prepare("INSERT IN cars VALUES(?, ?, ?)").bind(2, "Mercedes", 57127).run()
             }
-
-            let count: Int? = try connection.query("SELECT count(*) FROM cars")
-
-            // Then
-            XCTAssertEqual(count, 0)
         } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+            // No-op: this is expected due to invalid SQL in second prepare statement
         }
+
+        let count: Int? = try connection.query("SELECT count(*) FROM cars")
+
+        // Then
+        XCTAssertEqual(count, 0)
     }
 
     // MARK: - Tests - Savepoints
 
-    func testThatConnectionCanExecuteSavepoint() {
-        do {
-            // Given
-            try connection.execute("CREATE TABLE cars(id INTEGER PRIMARY KEY, name TEXT, price INTEGER)")
+    func testThatConnectionCanExecuteSavepoint() throws {
+        // Given
+        try connection.execute("CREATE TABLE cars(id INTEGER PRIMARY KEY, name TEXT, price INTEGER)")
 
-            // When
-            try connection.savepoint(named: "'savepoint-1'") {
+        // When
+        try connection.savepoint(named: "'savepoint-1'") {
+            try connection.prepare("INSERT INTO cars VALUES(?, ?, ?)").bind(1, "Audi", 52642).run()
+
+            try connection.savepoint(named: "'savepoint    2") {
+                try connection.prepare("INSERT INTO cars VALUES(?, ?, ?)").bind(2, "Mercedes", 57127).run()
+            }
+        }
+
+        // When
+        let rows: [[Any?]] = try connection.query("SELECT * FROM cars") { $0.values }
+
+        // Then
+        if rows.count == 2 {
+            XCTAssertEqual(rows[0][0] as? Int64, 1)
+            XCTAssertEqual(rows[0][1] as? String, "Audi")
+            XCTAssertEqual(rows[0][2] as? Int64, 52642)
+
+            XCTAssertEqual(rows[1][0] as? Int64, 2)
+            XCTAssertEqual(rows[1][1] as? String, "Mercedes")
+            XCTAssertEqual(rows[1][2] as? Int64, 57127)
+        } else {
+            XCTFail("rows count should be 2")
+        }
+    }
+
+    func testThatConnectionCanRollbackToSavepointWhenSavepointExecutionThrows() throws {
+        // Given
+        try connection.execute("CREATE TABLE cars(id INTEGER PRIMARY KEY, name TEXT, price INTEGER)")
+
+        // When
+        do {
+            try connection.savepoint(named: "save-it-up") {
                 try connection.prepare("INSERT INTO cars VALUES(?, ?, ?)").bind(1, "Audi", 52642).run()
-
-                try connection.savepoint(named: "'savepoint    2") {
-                    try connection.prepare("INSERT INTO cars VALUES(?, ?, ?)").bind(2, "Mercedes", 57127).run()
-                }
-            }
-
-            // When
-            let rows: [[Any?]] = try connection.query("SELECT * FROM cars") { $0.values }
-
-            // Then
-            if rows.count == 2 {
-                XCTAssertEqual(rows[0][0] as? Int64, 1, "rows[0][0] should be 1")
-                XCTAssertEqual(rows[0][1] as? String, "Audi", "rows[0][1] should be `Audi`")
-                XCTAssertEqual(rows[0][2] as? Int64, 52642, "rows[0][2] should be 52642")
-
-                XCTAssertEqual(rows[1][0] as? Int64, 2, "rows[1][0] should be 2")
-                XCTAssertEqual(rows[1][1] as? String, "Mercedes", "rows[1][1] should be `Mercedes`")
-                XCTAssertEqual(rows[1][2] as? Int64, 57127, "rows[1][2] should be 57127")
-            } else {
-                XCTFail("rows count should be 2")
+                try connection.prepare("INSERT IN cars VALUES(?, ?, ?)").bind(2, "Mercedes", 57127).run()
             }
         } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+            // No-op: this is expected due to invalid SQL in second prepare statement
         }
+
+        let count: Int? = try connection.query("SELECT count(*) FROM cars")
+
+        // Then
+        XCTAssertEqual(count, 0)
     }
 
-    func testThatConnectionCanRollbackToSavepointWhenSavepointExecutionThrows() {
-        do {
-            // Given
-            try connection.execute("CREATE TABLE cars(id INTEGER PRIMARY KEY, name TEXT, price INTEGER)")
+    func testThatConnectionCanExecuteSavepointsWithCrazyCharactersInName() throws {
+        // Given
+        try connection.execute("CREATE TABLE cars(id INTEGER PRIMARY KEY, name TEXT, price INTEGER)")
 
-            // When
-            do {
-                try connection.savepoint(named: "save-it-up") {
-                    try connection.prepare("INSERT INTO cars VALUES(?, ?, ?)").bind(1, "Audi", 52642).run()
-                    try connection.prepare("INSERT IN cars VALUES(?, ?, ?)").bind(2, "Mercedes", 57127).run()
-                }
-            } catch {
-                // No-op: this is expected due to invalid SQL in second prepare statement
+        // When
+        try connection.savepoint(named: "savè mę 😱 \n\r\n nõw \n plèãśę  ") {
+            try connection.run("INSERT INTO cars VALUES(?, ?, ?)", 1, "Audi", 52642)
+
+            try connection.savepoint(named: "  save with' random \" chàracters") {
+                try connection.run("INSERT INTO cars VALUES(?, ?, ?)", 2, "Mercedes", 57127)
             }
-
-            let count: Int? = try connection.query("SELECT count(*) FROM cars")
-
-            // Then
-            XCTAssertEqual(count, 0)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
         }
-    }
 
-    func testThatConnectionCanExecuteSavepointsWithCrazyCharactersInName() {
-        do {
-            // Given
-            try connection.execute("CREATE TABLE cars(id INTEGER PRIMARY KEY, name TEXT, price INTEGER)")
+        // When
+        let rows: [[Any?]] = try connection.query("SELECT * FROM cars") { $0.values }
 
-            // When
-            try connection.savepoint(named: "savè mę 😱 \n\r\n nõw \n plèãśę  ") {
-                try connection.run("INSERT INTO cars VALUES(?, ?, ?)", 1, "Audi", 52642)
+        // Then
+        if rows.count == 2 {
+            XCTAssertEqual(rows[0][0] as? Int64, 1)
+            XCTAssertEqual(rows[0][1] as? String, "Audi")
+            XCTAssertEqual(rows[0][2] as? Int64, 52642)
 
-                try connection.savepoint(named: "  save with' random \" chàracters") {
-                    try connection.run("INSERT INTO cars VALUES(?, ?, ?)", 2, "Mercedes", 57127)
-                }
-            }
-
-            // When
-            let rows: [[Any?]] = try connection.query("SELECT * FROM cars") { $0.values }
-
-            // Then
-            if rows.count == 2 {
-                XCTAssertEqual(rows[0][0] as? Int64, 1, "rows[0][0] should be 1")
-                XCTAssertEqual(rows[0][1] as? String, "Audi", "rows[0][1] should be `Audi`")
-                XCTAssertEqual(rows[0][2] as? Int64, 52642, "rows[0][2] should be 52642")
-
-                XCTAssertEqual(rows[1][0] as? Int64, 2, "rows[1][0] should be 2")
-                XCTAssertEqual(rows[1][1] as? String, "Mercedes", "rows[1][1] should be `Mercedes`")
-                XCTAssertEqual(rows[1][2] as? Int64, 57127, "rows[1][2] should be 57127")
-            } else {
-                XCTFail("rows count should be 2")
-            }
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+            XCTAssertEqual(rows[1][0] as? Int64, 2)
+            XCTAssertEqual(rows[1][1] as? String, "Mercedes")
+            XCTAssertEqual(rows[1][2] as? Int64, 57127)
+        } else {
+            XCTFail("rows count should be 2")
         }
     }
 }

--- a/Tests/Tests/Connection/StatementTests.swift
+++ b/Tests/Tests/Connection/StatementTests.swift
@@ -14,99 +14,83 @@ import SQLite3
 import XCTest
 
 class StatementTestCase: BaseConnectionTestCase {
-    func testThatStatementCanReturnWhetherItIsBusy() {
-        do {
-            // Given
-            let statement = try connection.prepare("SELECT name FROM agents WHERE missions > ?", 2_000)
+    func testThatStatementCanReturnWhetherItIsBusy() throws {
+        // Given
+        let statement = try connection.prepare("SELECT name FROM agents WHERE missions > ?", 2_000)
 
-            // When
-            let isBusyBeforeStep = statement.isBusy
-            _ = try statement.step()
-            let isBusyAfterFirstStep = statement.isBusy
-            _ = try statement.step()
-            let isBusyAfterSecondStep = statement.isBusy
+        // When
+        let isBusyBeforeStep = statement.isBusy
+        _ = try statement.step()
+        let isBusyAfterFirstStep = statement.isBusy
+        _ = try statement.step()
+        let isBusyAfterSecondStep = statement.isBusy
 
-            // Then
-            XCTAssertEqual(isBusyBeforeStep, false)
-            XCTAssertEqual(isBusyAfterFirstStep, true)
-            XCTAssertEqual(isBusyAfterSecondStep, false)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(isBusyBeforeStep, false)
+        XCTAssertEqual(isBusyAfterFirstStep, true)
+        XCTAssertEqual(isBusyAfterSecondStep, false)
     }
 
-    func testThatStatementCanReturnWhetherItIsReadOnly() {
-        do {
-            // Given
-            try connection.execute("CREATE TABLE person(id INTEGER PRIMARY KEY, first_name TEXT NOT NULL)")
+    func testThatStatementCanReturnWhetherItIsReadOnly() throws {
+        // Given
+        try connection.execute("CREATE TABLE person(id INTEGER PRIMARY KEY, first_name TEXT NOT NULL)")
 
-            // When
-            let insertStatement = try connection.prepare("INSERT INTO person(first_name) VALUES('Sterling')")
-            let updateStatement = try connection.prepare("UPDATE person SET first_name = 'Lana' WHERE id = 1")
-            let deleteStatement = try connection.prepare("DELETE FROM person WHERE id = 1")
-            let selectStatement = try connection.prepare("SELECT * FROM person")
+        // When
+        let insertStatement = try connection.prepare("INSERT INTO person(first_name) VALUES('Sterling')")
+        let updateStatement = try connection.prepare("UPDATE person SET first_name = 'Lana' WHERE id = 1")
+        let deleteStatement = try connection.prepare("DELETE FROM person WHERE id = 1")
+        let selectStatement = try connection.prepare("SELECT * FROM person")
 
-            // Then
-            XCTAssertEqual(insertStatement.isReadOnly, false)
-            XCTAssertEqual(updateStatement.isReadOnly, false)
-            XCTAssertEqual(deleteStatement.isReadOnly, false)
-            XCTAssertEqual(selectStatement.isReadOnly, true)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(insertStatement.isReadOnly, false)
+        XCTAssertEqual(updateStatement.isReadOnly, false)
+        XCTAssertEqual(deleteStatement.isReadOnly, false)
+        XCTAssertEqual(selectStatement.isReadOnly, true)
     }
 
-    func testThatStatementCanReturnSQLBoundWithParameters() {
-        do {
-            // Given
-            try connection.execute("CREATE TABLE person(id INTEGER PRIMARY KEY, first_name TEXT NOT NULL)")
+    func testThatStatementCanReturnSQLBoundWithParameters() throws {
+        // Given
+        try connection.execute("CREATE TABLE person(id INTEGER PRIMARY KEY, first_name TEXT NOT NULL)")
 
-            let insertStatement = try connection.prepare("INSERT INTO person(first_name) VALUES(?)", "Sterling")
-            let updateStatement = try connection.prepare("UPDATE person SET first_name = ? WHERE id = ?", "Lana", 1)
-            let deleteStatement = try connection.prepare("DELETE FROM person WHERE id = ?", 1)
-            let selectStatement = try connection.prepare("SELECT * FROM person WHERE id = ?", 1)
+        let insertStatement = try connection.prepare("INSERT INTO person(first_name) VALUES(?)", "Sterling")
+        let updateStatement = try connection.prepare("UPDATE person SET first_name = ? WHERE id = ?", "Lana", 1)
+        let deleteStatement = try connection.prepare("DELETE FROM person WHERE id = ?", 1)
+        let selectStatement = try connection.prepare("SELECT * FROM person WHERE id = ?", 1)
 
-            // When
-            let insertSQL = insertStatement.sql
-            let updateSQL = updateStatement.sql
-            let deleteSQL = deleteStatement.sql
-            let selectSQL = selectStatement.sql
+        // When
+        let insertSQL = insertStatement.sql
+        let updateSQL = updateStatement.sql
+        let deleteSQL = deleteStatement.sql
+        let selectSQL = selectStatement.sql
 
-            // Then
-            XCTAssertEqual(insertSQL, "INSERT INTO person(first_name) VALUES(?)")
-            XCTAssertEqual(updateSQL, "UPDATE person SET first_name = ? WHERE id = ?")
-            XCTAssertEqual(deleteSQL, "DELETE FROM person WHERE id = ?")
-            XCTAssertEqual(selectSQL, "SELECT * FROM person WHERE id = ?")
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(insertSQL, "INSERT INTO person(first_name) VALUES(?)")
+        XCTAssertEqual(updateSQL, "UPDATE person SET first_name = ? WHERE id = ?")
+        XCTAssertEqual(deleteSQL, "DELETE FROM person WHERE id = ?")
+        XCTAssertEqual(selectSQL, "SELECT * FROM person WHERE id = ?")
     }
 
-    func testThatStatementCanReturnExpandedSQLBoundWithParameters() {
+    func testThatStatementCanReturnExpandedSQLBoundWithParameters() throws {
         guard #available(iOS 10.0, macOS 10.12.0, tvOS 10.0, watchOS 3.0, *) else { return }
 
-        do {
-            // Given
-            try connection.execute("CREATE TABLE person(id INTEGER PRIMARY KEY, first_name TEXT NOT NULL)")
+        // Given
+        try connection.execute("CREATE TABLE person(id INTEGER PRIMARY KEY, first_name TEXT NOT NULL)")
 
-            let insertStatement = try connection.prepare("INSERT INTO person(first_name) VALUES(?)", "Sterling")
-            let updateStatement = try connection.prepare("UPDATE person SET first_name = ? WHERE id = ?", "Lana", 1)
-            let deleteStatement = try connection.prepare("DELETE FROM person WHERE id = ?", 1)
-            let selectStatement = try connection.prepare("SELECT * FROM person WHERE id = ?", 1)
+        let insertStatement = try connection.prepare("INSERT INTO person(first_name) VALUES(?)", "Sterling")
+        let updateStatement = try connection.prepare("UPDATE person SET first_name = ? WHERE id = ?", "Lana", 1)
+        let deleteStatement = try connection.prepare("DELETE FROM person WHERE id = ?", 1)
+        let selectStatement = try connection.prepare("SELECT * FROM person WHERE id = ?", 1)
 
-            // When
-            let insertSQL = insertStatement.expandedSQL
-            let updateSQL = updateStatement.expandedSQL
-            let deleteSQL = deleteStatement.expandedSQL
-            let selectSQL = selectStatement.expandedSQL
+        // When
+        let insertSQL = insertStatement.expandedSQL
+        let updateSQL = updateStatement.expandedSQL
+        let deleteSQL = deleteStatement.expandedSQL
+        let selectSQL = selectStatement.expandedSQL
 
-            // Then
-            XCTAssertEqual(insertSQL, "INSERT INTO person(first_name) VALUES('Sterling')")
-            XCTAssertEqual(updateSQL, "UPDATE person SET first_name = 'Lana' WHERE id = 1")
-            XCTAssertEqual(deleteSQL, "DELETE FROM person WHERE id = 1")
-            XCTAssertEqual(selectSQL, "SELECT * FROM person WHERE id = 1")
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(insertSQL, "INSERT INTO person(first_name) VALUES('Sterling')")
+        XCTAssertEqual(updateSQL, "UPDATE person SET first_name = 'Lana' WHERE id = 1")
+        XCTAssertEqual(deleteSQL, "DELETE FROM person WHERE id = 1")
+        XCTAssertEqual(selectSQL, "SELECT * FROM person WHERE id = 1")
     }
 }

--- a/Tests/Tests/Database/DatabaseTests.swift
+++ b/Tests/Tests/Database/DatabaseTests.swift
@@ -33,44 +33,36 @@ class DatabaseTestCase: BaseTestCase {
 
     // MARK: - Tests
 
-    func testThatDatabaseCanBeInitializedWithAllStorageLocations() {
+    func testThatDatabaseCanBeInitializedWithAllStorageLocations() throws {
         // Given, When, Then
-        do {
-            let _ = try Database(storageLocation: storageLocation)
-            let _ = try Database(storageLocation: .inMemory)
-            let _ = try Database(storageLocation: .temporary)
-            let _ = try Database(storageLocation: storageLocation, flags: SQLITE_OPEN_READONLY)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        let _ = try Database(storageLocation: storageLocation)
+        let _ = try Database(storageLocation: .inMemory)
+        let _ = try Database(storageLocation: .temporary)
+        let _ = try Database(storageLocation: storageLocation, flags: SQLITE_OPEN_READONLY)
     }
 
-    func testThatDatabaseInitializationExecutesWriterConnectionPreparationClosure() {
-        do {
-            // Given
-            let database = try Database(
-                storageLocation: storageLocation,
-                writerConnectionPreparation: { connection in
-                    try connection.execute("PRAGMA foreign_keys = ON")
-                    try connection.execute("PRAGMA synchronous = 1")
-                }
-            )
-
-            var foreignKeys: Int?
-            var synchronous: Int? = 0
-
-            // When
-            try database.writerConnectionQueue.execute { connection in
-                foreignKeys = try connection.query("PRAGMA foreign_keys")
-                synchronous = try connection.query("PRAGMA synchronous")
+    func testThatDatabaseInitializationExecutesWriterConnectionPreparationClosure() throws {
+        // Given
+        let database = try Database(
+            storageLocation: storageLocation,
+            writerConnectionPreparation: { connection in
+                try connection.execute("PRAGMA foreign_keys = ON")
+                try connection.execute("PRAGMA synchronous = 1")
             }
+        )
 
-            // Then
-            XCTAssertEqual(foreignKeys, 1)
-            XCTAssertEqual(synchronous, 1)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+        var foreignKeys: Int?
+        var synchronous: Int? = 0
+
+        // When
+        try database.writerConnectionQueue.execute { connection in
+            foreignKeys = try connection.query("PRAGMA foreign_keys")
+            synchronous = try connection.query("PRAGMA synchronous")
         }
+
+        // Then
+        XCTAssertEqual(foreignKeys, 1)
+        XCTAssertEqual(synchronous, 1)
     }
 
     func testThatDatabaseFailsToInitializeWithInvalidOnDiskStorageLocation() {
@@ -87,153 +79,141 @@ class DatabaseTestCase: BaseTestCase {
         }
     }
 
-    func testThatDatabaseCanExecuteRead() {
-        do {
-            // Given, When, Then
-            let database = try Database(storageLocation: storageLocation)
+    func testThatDatabaseCanExecuteRead() throws {
+        // Given
+        let database = try Database(storageLocation: storageLocation)
 
-            // When
-            var areValuesEqual: Bool?
+        // When
+        var areValuesEqual: Bool?
 
-            try database.executeRead { connection in
-                areValuesEqual = try connection.query("SELECT ? = ?", 1, 2)
-            }
-
-            // Then
-            XCTAssertEqual(areValuesEqual, false)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+        try database.executeRead { connection in
+            areValuesEqual = try connection.query("SELECT ? = ?", 1, 2)
         }
+
+        // Then
+        XCTAssertEqual(areValuesEqual, false)
     }
 
-    func testThatDatabaseCanExecuteWrite() {
-        do {
-            // Given, When, Then
-            let database = try Database(storageLocation: storageLocation)
+    func testThatDatabaseCanExecuteWrite() throws {
+        // Given
+        let database = try Database(storageLocation: storageLocation)
 
-            // When
-            var tableExists: Bool?
+        // When
+        var tableExists: Bool?
 
-            try database.executeWrite { connection in
-                try connection.run("CREATE TABLE agent(name TEXT PRIMARY KEY)")
-                tableExists = try connection.query("SELECT count(*) FROM sqlite_master WHERE type = ?", "table")
-            }
-
-            // Then
-            XCTAssertEqual(tableExists, true)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+        try database.executeWrite { connection in
+            try connection.run("CREATE TABLE agent(name TEXT PRIMARY KEY)")
+            tableExists = try connection.query("SELECT count(*) FROM sqlite_master WHERE type = ?", "table")
         }
+
+        // Then
+        XCTAssertEqual(tableExists, true)
     }
 
-    func testThatDatabaseCanSpitUpNewReadConnectionsThatContainLatestWrittenChanges() {
-        do {
-            // Given
-            let database = try Database(
-                storageLocation: storageLocation,
-                multiThreaded: true,
-                sharedCache: true,
-                writerConnectionPreparation: { connection in
-                    try connection.execute("""
+    func testThatDatabaseCanSpitUpNewReadConnectionsThatContainLatestWrittenChanges() throws {
+        // Given
+        let database = try Database(
+            storageLocation: storageLocation,
+            multiThreaded: true,
+            sharedCache: true,
+            writerConnectionPreparation: { connection in
+                try connection.execute("""
                         PRAGMA journal_mode = WAL;
                         PRAGMA cache_size = -10000
                         """
-                    ) // 10 MB max in-memory cache size
-                }
+                ) // 10 MB max in-memory cache size
+            }
+        )
+
+        try database.executeWrite { connection in
+            try connection.execute("""
+                CREATE TABLE person(id INTEGER PRIMARY KEY, first_name TEXT NOT NULL, last_name TEXT NOT NULL)
+                """
             )
 
-            try database.executeWrite { connection in
-                try connection.execute("""
-                    CREATE TABLE person(id INTEGER PRIMARY KEY, first_name TEXT NOT NULL, last_name TEXT NOT NULL)
-                    """
-                )
-
-                try TestTables.createAndPopulateAgentsTable(using: connection)
-                try TestTables.insertDummyAgents(count: 10_000, connection: connection)
-            }
-
-            let expectation = self.expectation(description: "Query should return agents and blocks checkpointing")
-            var agentQueryError: Error?
-            var agents: [Agent]?
-
-            DispatchQueue.userInitiated.async {
-                do {
-                    try database.executeRead { agents = try $0.query("SELECT * FROM agents") }
-                    expectation.fulfill()
-                } catch {
-                    agentQueryError = error
-                }
-            }
-
-            var writeError: Error?
-            var readError1: Error?
-            var readError2: Error?
-            var personBeforeCheckpoint1: Person?
-            var personBeforeCheckpoint2: Person?
-
-            // When
-            DispatchQueue.userInitiated.asyncAfter(seconds: 0.1) {
-                do {
-                    try database.executeWrite { connection in
-                        try connection.execute("INSERT INTO person(first_name, last_name) VALUES('Sterling', 'Archer')")
-                    }
-
-                    DispatchQueue.userInitiated.async {
-                        do {
-                            try database.executeRead { connection in
-                                personBeforeCheckpoint1 = try connection.query("SELECT * FROM person WHERE id = 1")
-                            }
-                        } catch {
-                            readError1 = error
-                        }
-                    }
-
-                    DispatchQueue.userInitiated.async {
-                        do {
-                            try database.executeRead { connection in
-                                personBeforeCheckpoint2 = try connection.query("SELECT * FROM person WHERE id = 1")
-                            }
-                        } catch {
-                            readError2 = error
-                        }
-                    }
-                } catch {
-                    writeError = error
-                }
-            }
-
-            waitForExpectations(timeout: timeout, handler: nil)
-
-            var personAfterCheckpoint: Person?
-            try database.executeRead { personAfterCheckpoint = try $0.query("SELECT * FROM person WHERE id = 1") }
-
-            var cacheSize: Int64 = -1
-            var pageSize: Int64 = -1
-
-            try database.executeRead { cacheSize = try $0.query("PRAGMA cache_size") ?? -1 }
-            try database.executeRead { pageSize = try $0.query("PRAGMA page_size") ?? -1 }
-
-            // Then
-            XCTAssertNil(agentQueryError)
-            XCTAssertEqual(agents?.count, 10_002)
-
-            XCTAssertNil(writeError)
-            XCTAssertNil(readError1)
-            XCTAssertNil(readError2)
-
-            XCTAssertEqual(personBeforeCheckpoint1?.firstName, "Sterling")
-            XCTAssertEqual(personBeforeCheckpoint1?.lastName, "Archer")
-
-            XCTAssertEqual(personBeforeCheckpoint2?.firstName, "Sterling")
-            XCTAssertEqual(personBeforeCheckpoint2?.lastName, "Archer")
-
-            XCTAssertEqual(personAfterCheckpoint?.firstName, "Sterling")
-            XCTAssertEqual(personAfterCheckpoint?.lastName, "Archer")
-
-            XCTAssertEqual(cacheSize, -10_000)
-            XCTAssertEqual(pageSize, 4_096)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+            try TestTables.createAndPopulateAgentsTable(using: connection)
+            try TestTables.insertDummyAgents(count: 10_000, connection: connection)
         }
+
+        let expectation = self.expectation(description: "Query should return agents and blocks checkpointing")
+        var agentQueryError: Error?
+        var agents: [Agent]?
+
+        DispatchQueue.userInitiated.async {
+            do {
+                try database.executeRead { agents = try $0.query("SELECT * FROM agents") }
+                expectation.fulfill()
+            } catch {
+                agentQueryError = error
+            }
+        }
+
+        var writeError: Error?
+        var readError1: Error?
+        var readError2: Error?
+        var personBeforeCheckpoint1: Person?
+        var personBeforeCheckpoint2: Person?
+
+        // When
+        DispatchQueue.userInitiated.asyncAfter(seconds: 0.1) {
+            do {
+                try database.executeWrite { connection in
+                    try connection.execute("INSERT INTO person(first_name, last_name) VALUES('Sterling', 'Archer')")
+                }
+
+                DispatchQueue.userInitiated.async {
+                    do {
+                        try database.executeRead { connection in
+                            personBeforeCheckpoint1 = try connection.query("SELECT * FROM person WHERE id = 1")
+                        }
+                    } catch {
+                        readError1 = error
+                    }
+                }
+
+                DispatchQueue.userInitiated.async {
+                    do {
+                        try database.executeRead { connection in
+                            personBeforeCheckpoint2 = try connection.query("SELECT * FROM person WHERE id = 1")
+                        }
+                    } catch {
+                        readError2 = error
+                    }
+                }
+            } catch {
+                writeError = error
+            }
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        var personAfterCheckpoint: Person?
+        try database.executeRead { personAfterCheckpoint = try $0.query("SELECT * FROM person WHERE id = 1") }
+
+        var cacheSize: Int64 = -1
+        var pageSize: Int64 = -1
+
+        try database.executeRead { cacheSize = try $0.query("PRAGMA cache_size") ?? -1 }
+        try database.executeRead { pageSize = try $0.query("PRAGMA page_size") ?? -1 }
+
+        // Then
+        XCTAssertNil(agentQueryError)
+        XCTAssertEqual(agents?.count, 10_002)
+
+        XCTAssertNil(writeError)
+        XCTAssertNil(readError1)
+        XCTAssertNil(readError2)
+
+        XCTAssertEqual(personBeforeCheckpoint1?.firstName, "Sterling")
+        XCTAssertEqual(personBeforeCheckpoint1?.lastName, "Archer")
+
+        XCTAssertEqual(personBeforeCheckpoint2?.firstName, "Sterling")
+        XCTAssertEqual(personBeforeCheckpoint2?.lastName, "Archer")
+
+        XCTAssertEqual(personAfterCheckpoint?.firstName, "Sterling")
+        XCTAssertEqual(personAfterCheckpoint?.lastName, "Archer")
+
+        XCTAssertEqual(cacheSize, -10_000)
+        XCTAssertEqual(pageSize, 4_096)
     }
 }

--- a/Tests/Tests/Database/MigratorTests.swift
+++ b/Tests/Tests/Database/MigratorTests.swift
@@ -13,407 +13,374 @@ import Foundation
 import XCTest
 
 class MigratorTestCase: BaseTestCase {
-    func testThatMigratorCanCreateMigrationsTable() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            let migrator = Migrator(connection: connection, desiredSchemaVersion: 1)
+    func testThatMigratorCanCreateMigrationsTable() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        let migrator = Migrator(connection: connection, desiredSchemaVersion: 1)
 
-            // When
-            try migrator.createMigrationTable()
-            let exists: Bool? = try connection.query(
-                "SELECT count(*) FROM sqlite_master WHERE type=? AND name=?",
-                "table",
-                "schema_migrations"
-            )
+        // When
+        try migrator.createMigrationTable()
+        let exists: Bool? = try connection.query(
+            "SELECT count(*) FROM sqlite_master WHERE type=? AND name=?",
+            "table",
+            "schema_migrations"
+        )
 
-            // Then
-            XCTAssertEqual(exists, true)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(exists, true)
     }
 
-    func testThatMigratorDoesNotThrowWhenCreatingMigrationsTableWhenTableAlreadyExists() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            let migrator = Migrator(connection: connection, desiredSchemaVersion: 1)
+    func testThatMigratorDoesNotThrowWhenCreatingMigrationsTableWhenTableAlreadyExists() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        let migrator = Migrator(connection: connection, desiredSchemaVersion: 1)
 
-            // When
-            try migrator.createMigrationTable()
-            try migrator.createMigrationTable()
+        // When
+        try migrator.createMigrationTable()
+        try migrator.createMigrationTable()
 
-            let exists: Bool? = try connection.query(
-                "SELECT count(*) FROM sqlite_master WHERE type=? AND name=?",
-                "table",
-                "schema_migrations"
-            )
+        let exists: Bool? = try connection.query(
+            "SELECT count(*) FROM sqlite_master WHERE type=? AND name=?",
+            "table",
+            "schema_migrations"
+        )
 
-            // Then
-            XCTAssertEqual(exists, true)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(exists, true)
     }
 
-    func testThatMigratorMigrationsTableExistsPropertyReturnsFalseIfTableDoesNotExists() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            let migrator = Migrator(connection: connection, desiredSchemaVersion: 1)
+    func testThatMigratorMigrationsTableExistsPropertyReturnsFalseIfTableDoesNotExists() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        let migrator = Migrator(connection: connection, desiredSchemaVersion: 1)
 
-            // When
-            try connection.execute("DROP TABLE IF EXISTS schema_migrations")
-            let tableExists = migrator.migrationTableExists
+        // When
+        try connection.execute("DROP TABLE IF EXISTS schema_migrations")
+        let tableExists = migrator.migrationTableExists
 
-            // Then
-            XCTAssertFalse(tableExists)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertFalse(tableExists)
     }
 
-    func testThatMigratorMigrationsTableExistsPropertyReturnsTrueIfTableExists() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            let migrator = Migrator(connection: connection, desiredSchemaVersion: 1)
+    func testThatMigratorMigrationsTableExistsPropertyReturnsTrueIfTableExists() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        let migrator = Migrator(connection: connection, desiredSchemaVersion: 1)
 
-            // When
-            try migrator.createMigrationTable()
-            let tableExists = migrator.migrationTableExists
+        // When
+        try migrator.createMigrationTable()
+        let tableExists = migrator.migrationTableExists
 
-            // Then
-            XCTAssertTrue(tableExists)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertTrue(tableExists)
     }
 
-    func testThatMigratorCanRunInitialMigration() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            let migrator = Migrator(connection: connection, desiredSchemaVersion: 1)
+    func testThatMigratorCanRunInitialMigration() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        let migrator = Migrator(connection: connection, desiredSchemaVersion: 1)
 
-            let expectation = self.expectation(description: "migrations should complete successfully")
+        let expectation = self.expectation(description: "migrations should complete successfully")
 
-            var willMigrate: [UInt64] = []
-            var didMigrate: [UInt64] = []
-            var migrationError: Error?
-            var agentsTableExists: Bool?
+        var willMigrate: [UInt64] = []
+        var didMigrate: [UInt64] = []
+        var migrationError: Error?
+        var agentsTableExists: Bool?
 
-            // When
-            DispatchQueue.utility.async {
-                do {
-                    try migrator.runMigrationsIfNecessary(
-                        migrationSQLForSchemaVersion: { version in
+        // When
+        DispatchQueue.utility.async {
+            do {
+                try migrator.runMigrationsIfNecessary(
+                    migrationSQLForSchemaVersion: { version in
+                        return "CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT NOT NULL)"
+                    },
+                    willMigrateToSchemaVersion: { version in
+                        willMigrate.append(version)
+                    },
+                    didMigrateToSchemaVersion: { version in
+                        didMigrate.append(version)
+                    }
+                )
+
+                agentsTableExists = try connection.query(
+                    "SELECT count(*) FROM sqlite_master WHERE type = ? AND name = ?",
+                    "table",
+                    "agents"
+                )
+            } catch {
+                migrationError = error
+            }
+
+            expectation.fulfill()
+        }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        XCTAssertEqual(willMigrate.count, 1)
+        XCTAssertEqual(didMigrate.count, 1)
+        XCTAssertNil(migrationError)
+        XCTAssertEqual(agentsTableExists, true)
+    }
+
+    func testThatMigratorCanRunMultipleMigrations() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        let migrator = Migrator(connection: connection, desiredSchemaVersion: 2)
+
+        let expectation = self.expectation(description: "migrations should complete successfully")
+
+        var willMigrate: [UInt64] = []
+        var didMigrate: [UInt64] = []
+        var migrationError: Error? = nil
+        var agentsTableExists: Bool?
+        var agentCount: Int?
+
+        // When
+        DispatchQueue.utility.async {
+            do {
+                try migrator.runMigrationsIfNecessary(
+                    migrationSQLForSchemaVersion: { version in
+                        switch version {
+                        case 1:
                             return "CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT NOT NULL)"
-                        },
-                        willMigrateToSchemaVersion: { version in
-                            willMigrate.append(version)
-                        },
-                        didMigrateToSchemaVersion: { version in
-                            didMigrate.append(version)
+
+                        default:
+                            return """
+                            INSERT INTO agents(name) VALUES('Sterling Archer');
+                            INSERT INTO agents(name) VALUES('Lana Kane')
+                            """
                         }
-                    )
+                    },
+                    willMigrateToSchemaVersion: { version in
+                        willMigrate.append(version)
+                    },
+                    didMigrateToSchemaVersion: { version in
+                        didMigrate.append(version)
+                    }
+                )
 
-                    agentsTableExists = try connection.query(
-                        "SELECT count(*) FROM sqlite_master WHERE type = ? AND name = ?",
-                        "table",
-                        "agents"
-                    )
-                } catch {
-                    migrationError = error
-                }
+                agentsTableExists = try connection.query(
+                    "SELECT count(*) FROM sqlite_master WHERE type=? AND name=?",
+                    "table",
+                    "agents"
+                )
 
-                expectation.fulfill()
+                agentCount = try connection.query("SELECT count(*) FROM agents")
+            } catch {
+                migrationError = error
             }
 
-            waitForExpectations(timeout: timeout, handler: nil)
-
-            // Then
-            XCTAssertEqual(willMigrate.count, 1)
-            XCTAssertEqual(didMigrate.count, 1)
-            XCTAssertNil(migrationError)
-            XCTAssertEqual(agentsTableExists, true)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+            expectation.fulfill()
         }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        if willMigrate.count == 2 && didMigrate.count == 2 {
+            XCTAssertEqual(willMigrate[0], 1)
+            XCTAssertEqual(willMigrate[1], 2)
+
+            XCTAssertEqual(didMigrate[0], 1)
+            XCTAssertEqual(didMigrate[1], 2)
+        } else {
+            XCTFail("will and did migrate counts should be 2")
+        }
+
+        XCTAssertNil(migrationError)
+        XCTAssertEqual(agentsTableExists, true)
+        XCTAssertEqual(agentCount, 2)
     }
 
-    func testThatMigratorCanRunMultipleMigrations() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            let migrator = Migrator(connection: connection, desiredSchemaVersion: 2)
+    func testThatMigratorCanRunMigrationsBeyondTheInitialMigration() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        var migrator: Migrator? = Migrator(connection: connection, desiredSchemaVersion: 1)
 
-            let expectation = self.expectation(description: "migrations should complete successfully")
+        try migrator?.runMigrationsIfNecessary(
+            migrationSQLForSchemaVersion: { version in
+                return "CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT NOT NULL)"
+            }
+        )
 
-            var willMigrate: [UInt64] = []
-            var didMigrate: [UInt64] = []
-            var migrationError: Error? = nil
-            var agentsTableExists: Bool?
-            var agentCount: Int?
+        migrator = nil
+        migrator = Migrator(connection: connection, desiredSchemaVersion: 3)
 
-            // When
-            DispatchQueue.utility.async {
-                do {
-                    try migrator.runMigrationsIfNecessary(
-                        migrationSQLForSchemaVersion: { version in
-                            switch version {
-                            case 1:
-                                return "CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT NOT NULL)"
-                            default:
-                                return """
-                                    INSERT INTO agents(name) VALUES('Sterling Archer');
-                                    INSERT INTO agents(name) VALUES('Lana Kane')
-                                    """
-                            }
-                        },
-                        willMigrateToSchemaVersion: { version in
-                            willMigrate.append(version)
-                        },
-                        didMigrateToSchemaVersion: { version in
-                            didMigrate.append(version)
+        let expectation = self.expectation(description: "migrations should complete successfully")
+
+        var willMigrate: [UInt64] = []
+        var didMigrate: [UInt64] = []
+        var migrationError: Error? = nil
+
+        var agentCount: Int?
+        var missionsTableExists: Bool?
+
+        // When
+        DispatchQueue.utility.async {
+            do {
+                try migrator?.runMigrationsIfNecessary(
+                    migrationSQLForSchemaVersion: { version in
+                        switch version {
+                        case 2:
+                            return """
+                                INSERT INTO agents(name) VALUES('Sterling Archer');
+                                INSERT INTO agents(name) VALUES('Lana Kane')
+                                """
+
+                        default:
+                            return """
+                                CREATE TABLE missions(id INTEGER PRIMARY KEY AUTOINCREMENT, payment REAL NOT NULL)
+                                """
                         }
-                    )
+                    },
+                    willMigrateToSchemaVersion: { version in
+                        willMigrate.append(version)
+                    },
+                    didMigrateToSchemaVersion: { version in
+                        didMigrate.append(version)
+                    }
+                )
 
-                    agentsTableExists = try connection.query("SELECT count(*) FROM sqlite_master WHERE type=? AND name=?",
-                        "table",
-                        "agents"
-                    )
+                agentCount = try connection.query("SELECT count(*) FROM agents")
 
-                    agentCount = try connection.query("SELECT count(*) FROM agents")
-                } catch {
-                    migrationError = error
-                }
-
-                expectation.fulfill()
+                missionsTableExists = try connection.query(
+                    "SELECT count(*) FROM sqlite_master WHERE type=? AND name=?",
+                    "table",
+                    "missions"
+                )
+            } catch {
+                migrationError = error
             }
 
-            waitForExpectations(timeout: timeout, handler: nil)
-
-            // Then
-            if willMigrate.count == 2 && didMigrate.count == 2 {
-                XCTAssertEqual(willMigrate[0], 1)
-                XCTAssertEqual(willMigrate[1], 2)
-
-                XCTAssertEqual(didMigrate[0], 1)
-                XCTAssertEqual(didMigrate[1], 2)
-            } else {
-                XCTFail("will and did migrate counts should be 2")
-            }
-
-            XCTAssertNil(migrationError)
-            XCTAssertEqual(agentsTableExists, true)
-            XCTAssertEqual(agentCount, 2)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+            expectation.fulfill()
         }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        if willMigrate.count == 2 && didMigrate.count == 2 {
+            XCTAssertEqual(willMigrate[0], 2)
+            XCTAssertEqual(willMigrate[1], 3)
+
+            XCTAssertEqual(didMigrate[0], 2)
+            XCTAssertEqual(didMigrate[1], 3)
+        } else {
+            XCTFail("will and did migrate counts should be 2")
+        }
+
+        XCTAssertNil(migrationError)
+        XCTAssertEqual(agentCount, 2)
+        XCTAssertEqual(missionsTableExists, true)
     }
 
-    func testThatMigratorCanRunMigrationsBeyondTheInitialMigration() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            var migrator: Migrator? = Migrator(connection: connection, desiredSchemaVersion: 1)
+    func testThatMigratorCanRunMigrationsByDelegatingMigrationToTheCaller() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        let migrator = Migrator(connection: connection, desiredSchemaVersion: 2)
 
-            try migrator?.runMigrationsIfNecessary(
-                migrationSQLForSchemaVersion: { version in
-                    return "CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT NOT NULL)"
-                }
-            )
+        let expectation = self.expectation(description: "migrations should complete successfully")
 
-            migrator = nil
-            migrator = Migrator(connection: connection, desiredSchemaVersion: 3)
+        var willMigrate: [UInt64] = []
+        var didMigrate: [UInt64] = []
+        var migrationError: Error? = nil
+        var agentsTableExists: Bool?
+        var agentCount: Int?
 
-            let expectation = self.expectation(description: "migrations should complete successfully")
-
-            var willMigrate: [UInt64] = []
-            var didMigrate: [UInt64] = []
-            var migrationError: Error? = nil
-
-            var agentCount: Int?
-            var missionsTableExists: Bool?
-
-            // When
-            DispatchQueue.utility.async {
-                do {
-                    try migrator?.runMigrationsIfNecessary(
-                        migrationSQLForSchemaVersion: { version in
-                            switch version {
-                            case 2:
-                                return """
-                                    INSERT INTO agents(name) VALUES('Sterling Archer');
-                                    INSERT INTO agents(name) VALUES('Lana Kane')
-                                    """
-
-                            default:
-                                return """
-                                    CREATE TABLE missions(id INTEGER PRIMARY KEY AUTOINCREMENT, payment REAL NOT NULL)
-                                    """
-                            }
-                        },
-                        willMigrateToSchemaVersion: { version in
-                            willMigrate.append(version)
-                        },
-                        didMigrateToSchemaVersion: { version in
-                            didMigrate.append(version)
+        // When
+        DispatchQueue.utility.async {
+            do {
+                try migrator.runMigrationsIfNecessary(
+                    migrateDatabaseToSchemaVersion: { version, connection in
+                        switch version {
+                        case 1:
+                            try connection.execute(
+                                "CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT NOT NULL)"
+                            )
+                        default:
+                            try connection.execute("""
+                                INSERT INTO agents(name) VALUES('Sterling Archer');
+                                INSERT INTO agents(name) VALUES('Lana Kane')
+                                """
+                            )
                         }
-                    )
+                    },
+                    willMigrateToSchemaVersion: { version in
+                        willMigrate.append(version)
+                    },
+                    didMigrateToSchemaVersion: { version in
+                        didMigrate.append(version)
+                    }
+                )
 
-                    agentCount = try connection.query("SELECT count(*) FROM agents")
+                agentsTableExists = try connection.query(
+                    "SELECT count(*) FROM sqlite_master WHERE type=? AND name=?",
+                    "table",
+                    "agents"
+                )
 
-                    missionsTableExists = try connection.query(
-                        "SELECT count(*) FROM sqlite_master WHERE type=? AND name=?",
-                        "table",
-                        "missions"
-                    )
-                } catch {
-                    migrationError = error
-                }
-
-                expectation.fulfill()
+                agentCount = try connection.query("SELECT count(*) FROM agents")
+            } catch {
+                migrationError = error
             }
 
-            waitForExpectations(timeout: timeout, handler: nil)
-
-            // Then
-            if willMigrate.count == 2 && didMigrate.count == 2 {
-                XCTAssertEqual(willMigrate[0], 2)
-                XCTAssertEqual(willMigrate[1], 3)
-
-                XCTAssertEqual(didMigrate[0], 2)
-                XCTAssertEqual(didMigrate[1], 3)
-            } else {
-                XCTFail("will and did migrate counts should be 2")
-            }
-
-            XCTAssertNil(migrationError)
-            XCTAssertEqual(agentCount, 2)
-            XCTAssertEqual(missionsTableExists, true)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+            expectation.fulfill()
         }
+
+        waitForExpectations(timeout: timeout, handler: nil)
+
+        // Then
+        if willMigrate.count == 2 && didMigrate.count == 2 {
+            XCTAssertEqual(willMigrate[0], 1)
+            XCTAssertEqual(willMigrate[1], 2)
+
+            XCTAssertEqual(didMigrate[0], 1)
+            XCTAssertEqual(didMigrate[1], 2)
+        } else {
+            XCTFail("will and did migrate counts should be 2")
+        }
+
+        XCTAssertNil(migrationError)
+        XCTAssertEqual(agentsTableExists, true)
+        XCTAssertEqual(agentCount, 2)
     }
 
-    func testThatMigratorCanRunMigrationsByDelegatingMigrationToTheCaller() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            let migrator = Migrator(connection: connection, desiredSchemaVersion: 2)
+    func testThatMigratorGracefullyHandlesErrorEncounteredDuringMigration() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        let migrator = Migrator(connection: connection, desiredSchemaVersion: 1)
 
-            let expectation = self.expectation(description: "migrations should complete successfully")
+        let expectation = self.expectation(description: "migrations should complete successfully")
 
-            var willMigrate: [UInt64] = []
-            var didMigrate: [UInt64] = []
-            var migrationError: Error? = nil
-            var agentsTableExists: Bool?
-            var agentCount: Int?
+        var willMigrate: [UInt64] = []
+        var didMigrate: [UInt64] = []
+        var migrationError: Error? = nil
 
-            // When
-            DispatchQueue.utility.async {
-                do {
-                    try migrator.runMigrationsIfNecessary(
-                        migrateDatabaseToSchemaVersion: { version, connection in
-                            switch version {
-                            case 1:
-                                try connection.execute(
-                                    "CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT NOT NULL)"
-                                )
-                            default:
-                                try connection.execute("""
-                                    INSERT INTO agents(name) VALUES('Sterling Archer');
-                                    INSERT INTO agents(name) VALUES('Lana Kane')
-                                    """
-                                )
-                            }
-                        },
-                        willMigrateToSchemaVersion: { version in
-                            willMigrate.append(version)
-                        },
-                        didMigrateToSchemaVersion: { version in
-                            didMigrate.append(version)
-                        }
-                    )
-
-                    agentsTableExists = try connection.query("SELECT count(*) FROM sqlite_master WHERE type=? AND name=?",
-                        "table",
-                        "agents"
-                    )
-
-                    agentCount = try connection.query("SELECT count(*) FROM agents")
-                } catch {
-                    migrationError = error
-                }
-
-                expectation.fulfill()
+        // When
+        DispatchQueue.utility.async {
+            do {
+                try migrator.runMigrationsIfNecessary(
+                    migrationSQLForSchemaVersion: { version in
+                        return "CREATE TABLETYPO agents(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)"
+                    },
+                    willMigrateToSchemaVersion: { version in
+                        willMigrate.append(version)
+                    },
+                    didMigrateToSchemaVersion: { version in
+                        didMigrate.append(version)
+                    }
+                )
+            } catch {
+                migrationError = error
             }
 
-            waitForExpectations(timeout: timeout, handler: nil)
-
-            // Then
-            if willMigrate.count == 2 && didMigrate.count == 2 {
-                XCTAssertEqual(willMigrate[0], 1)
-                XCTAssertEqual(willMigrate[1], 2)
-
-                XCTAssertEqual(didMigrate[0], 1)
-                XCTAssertEqual(didMigrate[1], 2)
-            } else {
-                XCTFail("will and did migrate counts should be 2")
-            }
-
-            XCTAssertNil(migrationError)
-            XCTAssertEqual(agentsTableExists, true)
-            XCTAssertEqual(agentCount, 2)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+            expectation.fulfill()
         }
-    }
 
-    func testThatMigratorGracefullyHandlesErrorEncounteredDuringMigration() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            let migrator = Migrator(connection: connection, desiredSchemaVersion: 1)
+        waitForExpectations(timeout: timeout, handler: nil)
 
-            let expectation = self.expectation(description: "migrations should complete successfully")
-
-            var willMigrate: [UInt64] = []
-            var didMigrate: [UInt64] = []
-            var migrationError: Error? = nil
-
-            // When
-            DispatchQueue.utility.async {
-                do {
-                    try migrator.runMigrationsIfNecessary(
-                        migrationSQLForSchemaVersion: { version in
-                            return "CREATE TABLETYPO agents(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT)"
-                        },
-                        willMigrateToSchemaVersion: { version in
-                            willMigrate.append(version)
-                        },
-                        didMigrateToSchemaVersion: { version in
-                            didMigrate.append(version)
-                        }
-                    )
-                } catch {
-                    migrationError = error
-                }
-
-                expectation.fulfill()
-            }
-
-            waitForExpectations(timeout: timeout, handler: nil)
-
-            // Then
-            XCTAssertEqual(willMigrate.count, 1)
-            XCTAssertEqual(didMigrate.count, 0)
-            XCTAssertNotNil(migrationError)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(willMigrate.count, 1)
+        XCTAssertEqual(didMigrate.count, 0)
+        XCTAssertNotNil(migrationError)
     }
 }

--- a/Tests/Tests/Errors/ExpressibleByRowErrorTests.swift
+++ b/Tests/Tests/Errors/ExpressibleByRowErrorTests.swift
@@ -13,37 +13,33 @@ import SQift
 import XCTest
 
 class ExpressibleByRowErrorTestCase: BaseConnectionTestCase {
-    func testThatExpressibleByRowErrorCanBeConstructedFromRow() {
-        do {
-            // Given
-            var error: ExpressibleByRowError?
+    func testThatExpressibleByRowErrorCanBeConstructedFromRow() throws {
+        // Given
+        var error: ExpressibleByRowError?
 
-            // When
-            if let row = try connection.query("SELECT name, missions FROM agents WHERE name='Lana Kane'") {
-                error = ExpressibleByRowError(type: Agent.self, row: row)
-            }
-
-            // Then
-            XCTAssertTrue(error?.type is Agent.Type)
-            XCTAssertEqual(error?.columns.count, 2)
-
-            let expectedDescription = "ExpressibleByRowError: Failed to initialize Agent from Row with columns: " +
-                "[{ index: 0 name: \"name\", type: \"text\", value: Lana Kane }, " +
-                "{ index: 1 name: \"missions\", type: \"integer\", value: 2315 }]"
-
-            let expectedErrorDescription = "Failed to initialize Agent from Row with columns: " +
-                "[{ index: 0 name: \"name\", type: \"text\", value: Lana Kane }, " +
-                "{ index: 1 name: \"missions\", type: \"integer\", value: 2315 }]"
-
-            let expectedFailureReason = "Agent could not be initialized from Row with columns: " +
-                "[{ index: 0 name: \"name\", type: \"text\", value: Lana Kane }, " +
-                "{ index: 1 name: \"missions\", type: \"integer\", value: 2315 }]"
-
-            XCTAssertEqual(error?.description, expectedDescription)
-            XCTAssertEqual(error?.errorDescription, expectedErrorDescription)
-            XCTAssertEqual(error?.failureReason, expectedFailureReason)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+        // When
+        if let row = try connection.query("SELECT name, missions FROM agents WHERE name='Lana Kane'") {
+            error = ExpressibleByRowError(type: Agent.self, row: row)
         }
+
+        // Then
+        XCTAssertTrue(error?.type is Agent.Type)
+        XCTAssertEqual(error?.columns.count, 2)
+
+        let expectedDescription = "ExpressibleByRowError: Failed to initialize Agent from Row with columns: " +
+            "[{ index: 0 name: \"name\", type: \"text\", value: Lana Kane }, " +
+            "{ index: 1 name: \"missions\", type: \"integer\", value: 2315 }]"
+
+        let expectedErrorDescription = "Failed to initialize Agent from Row with columns: " +
+            "[{ index: 0 name: \"name\", type: \"text\", value: Lana Kane }, " +
+            "{ index: 1 name: \"missions\", type: \"integer\", value: 2315 }]"
+
+        let expectedFailureReason = "Agent could not be initialized from Row with columns: " +
+            "[{ index: 0 name: \"name\", type: \"text\", value: Lana Kane }, " +
+            "{ index: 1 name: \"missions\", type: \"integer\", value: 2315 }]"
+
+        XCTAssertEqual(error?.description, expectedDescription)
+        XCTAssertEqual(error?.errorDescription, expectedErrorDescription)
+        XCTAssertEqual(error?.failureReason, expectedFailureReason)
     }
 }

--- a/Tests/Tests/Rows/BindingTests.swift
+++ b/Tests/Tests/Rows/BindingTests.swift
@@ -402,124 +402,104 @@ class BindingTestCase: BaseTestCase {
 
     // MARK: - Tests - Codable Binding
 
-    func testCodableBinding() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            try connection.execute("CREATE TABLE person(id INTEGER PRIMARY KEY, data BLOB NOT NULL)")
+    func testCodableBinding() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        try connection.execute("CREATE TABLE person(id INTEGER PRIMARY KEY, data BLOB NOT NULL)")
 
-            let archer = Person(firstName: "Sterling", lastName: "Archer", countries: ["USA", "France", "Belgium"], friends: 0, homes: 2)
-            let lana = Person(firstName: "Lana", lastName: "Kane", countries: ["USA", "China", "Russia"], friends: 1, homes: 20)
+        let archer = Person(firstName: "Sterling", lastName: "Archer", countries: ["USA", "France", "Belgium"], friends: 0, homes: 2)
+        let lana = Person(firstName: "Lana", lastName: "Kane", countries: ["USA", "China", "Russia"], friends: 1, homes: 20)
 
-            // When
-            try connection.run("INSERT INTO person(data) VALUES(?)", archer)
-            try connection.run("INSERT INTO person(data) VALUES(?)", lana)
+        // When
+        try connection.run("INSERT INTO person(data) VALUES(?)", archer)
+        try connection.run("INSERT INTO person(data) VALUES(?)", lana)
 
-            let archerQueried: Person? = try connection.query("SELECT data FROM person WHERE id = ?", 1)
-            let lanaQueried: Person? = try connection.query("SELECT data FROM person WHERE id = ?", 2)
+        let archerQueried: Person? = try connection.query("SELECT data FROM person WHERE id = ?", 1)
+        let lanaQueried: Person? = try connection.query("SELECT data FROM person WHERE id = ?", 2)
 
-            // Then
-            XCTAssertEqual(archerQueried, archer)
-            XCTAssertEqual(lanaQueried, lana)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(archerQueried, archer)
+        XCTAssertEqual(lanaQueried, lana)
     }
 
     // MARK: - Tests - Collection Bindings
 
-    func testArrayBinding() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            try connection.execute("CREATE TABLE stream(id INTEGER PRIMARY KEY, data BLOB NOT NULL)")
+    func testArrayBinding() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        try connection.execute("CREATE TABLE stream(id INTEGER PRIMARY KEY, data BLOB NOT NULL)")
 
-            let points: ArrayBinding = [
-                CGPoint(x: 1.0, y: 2.0),
-                CGPoint(x: 3.0, y: 4.0),
-                CGPoint(x: 5.0, y: 6.0),
-                CGPoint(x: 7.0, y: 8.0),
-                CGPoint(x: 9.0, y: 10.0)
-            ]
+        let points: ArrayBinding = [
+            CGPoint(x: 1.0, y: 2.0),
+            CGPoint(x: 3.0, y: 4.0),
+            CGPoint(x: 5.0, y: 6.0),
+            CGPoint(x: 7.0, y: 8.0),
+            CGPoint(x: 9.0, y: 10.0)
+        ]
 
-            // When
-            try connection.run("INSERT INTO stream(data) VALUES(?)", points)
-            let pointsQueried: ArrayBinding<CGPoint>? = try connection.query("SELECT data FROM stream WHERE id = ?", 1)
+        // When
+        try connection.run("INSERT INTO stream(data) VALUES(?)", points)
+        let pointsQueried: ArrayBinding<CGPoint>? = try connection.query("SELECT data FROM stream WHERE id = ?", 1)
 
-            // Then
-            XCTAssertEqual(pointsQueried?.elements ?? [], points.elements)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(pointsQueried?.elements ?? [], points.elements)
     }
 
-    func testArrayBindingOfCodableBindings() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            try connection.execute("CREATE TABLE stream(id INTEGER PRIMARY KEY, data BLOB NOT NULL)")
+    func testArrayBindingOfCodableBindings() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        try connection.execute("CREATE TABLE stream(id INTEGER PRIMARY KEY, data BLOB NOT NULL)")
 
-            let people: ArrayBinding = [
-                Person(firstName: "Sterling", lastName: "Archer", countries: ["USA", "France", "Belgium"], friends: 0, homes: 2),
-                Person(firstName: "Lana", lastName: "Kane", countries: ["USA", "China", "Russia"], friends: 1, homes: 20)
-            ]
+        let people: ArrayBinding = [
+            Person(firstName: "Sterling", lastName: "Archer", countries: ["USA", "France", "Belgium"], friends: 0, homes: 2),
+            Person(firstName: "Lana", lastName: "Kane", countries: ["USA", "China", "Russia"], friends: 1, homes: 20)
+        ]
 
-            // When
-            try connection.run("INSERT INTO stream(data) VALUES(?)", people)
-            let peopleQueried: ArrayBinding<Person>? = try connection.query("SELECT data FROM stream WHERE id = ?", 1)
+        // When
+        try connection.run("INSERT INTO stream(data) VALUES(?)", people)
+        let peopleQueried: ArrayBinding<Person>? = try connection.query("SELECT data FROM stream WHERE id = ?", 1)
 
-            // Then
-            XCTAssertEqual(peopleQueried?.elements ?? [], people.elements)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(peopleQueried?.elements ?? [], people.elements)
     }
 
-    func testSetBinding() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            try connection.execute("CREATE TABLE stream(id INTEGER PRIMARY KEY, data BLOB NOT NULL)")
+    func testSetBinding() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        try connection.execute("CREATE TABLE stream(id INTEGER PRIMARY KEY, data BLOB NOT NULL)")
 
-            let identifiers: SetBinding = [
-                UUID(),
-                UUID(),
-                UUID(),
-                UUID()
-            ]
+        let identifiers: SetBinding = [
+            UUID(),
+            UUID(),
+            UUID(),
+            UUID()
+        ]
 
-            // When
-            try connection.run("INSERT INTO stream(data) VALUES(?)", identifiers)
-            let identifiersQueried: SetBinding<UUID>? = try connection.query("SELECT data FROM stream WHERE id = ?", 1)
+        // When
+        try connection.run("INSERT INTO stream(data) VALUES(?)", identifiers)
+        let identifiersQueried: SetBinding<UUID>? = try connection.query("SELECT data FROM stream WHERE id = ?", 1)
 
-            // Then
-            XCTAssertEqual(identifiersQueried?.elements ?? [], identifiers.elements)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(identifiersQueried?.elements ?? [], identifiers.elements)
     }
 
-    func testDictionaryBinding() {
-        do {
-            // Given
-            let connection = try Connection(storageLocation: storageLocation)
-            try connection.execute("CREATE TABLE stream(id INTEGER PRIMARY KEY, data BLOB NOT NULL)")
+    func testDictionaryBinding() throws {
+        // Given
+        let connection = try Connection(storageLocation: storageLocation)
+        try connection.execute("CREATE TABLE stream(id INTEGER PRIMARY KEY, data BLOB NOT NULL)")
 
-            let capitals: DictionaryBinding = [
-                "Iowa": "Des Moines",
-                "Oregon": "Salem",
-                "California": "Sacremento",
-                "Washington": "Olympia"
-            ]
+        let capitals: DictionaryBinding = [
+            "Iowa": "Des Moines",
+            "Oregon": "Salem",
+            "California": "Sacremento",
+            "Washington": "Olympia"
+        ]
 
-            // When
-            try connection.run("INSERT INTO stream(data) VALUES(?)", capitals)
-            let capitalsQueried: DictionaryBinding<String, String>? = try connection.query("SELECT data FROM stream WHERE id = ?", 1)
+        // When
+        try connection.run("INSERT INTO stream(data) VALUES(?)", capitals)
+        let capitalsQueried: DictionaryBinding<String, String>? = try connection.query("SELECT data FROM stream WHERE id = ?", 1)
 
-            // Then
-            XCTAssertEqual(capitalsQueried?.elements ?? [:], capitals.elements)
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
-        }
+        // Then
+        XCTAssertEqual(capitalsQueried?.elements ?? [:], capitals.elements)
     }
 }

--- a/Tests/Tests/Rows/RowTests.swift
+++ b/Tests/Tests/Rows/RowTests.swift
@@ -16,366 +16,342 @@ class RowTestCase: BaseConnectionTestCase {
 
     // MARK: - Tests - Columns
 
-    func testThatRowCanAccessColumnInformation() {
-        do {
-            // Given
-            var columnCount = 0
-            var columns: [Row.Column] = []
+    func testThatRowCanAccessColumnInformation() throws {
+        // Given
+        var columnCount = 0
+        var columns: [Row.Column] = []
 
-            // When
-            if let row = try connection.query("SELECT * FROM agents WHERE name='Lana Kane'") {
-                columnCount = row.columnCount
-                columns = row.columns
-            }
+        // When
+        if let row = try connection.query("SELECT * FROM agents WHERE name='Lana Kane'") {
+            columnCount = row.columnCount
+            columns = row.columns
+        }
 
-            // Then
-            XCTAssertEqual(columnCount, 7)
-            XCTAssertEqual(columns.count, 7)
+        // Then
+        XCTAssertEqual(columnCount, 7)
+        XCTAssertEqual(columns.count, 7)
 
-            if columns.count == 7 {
-                let column0 = columns[0]
-                XCTAssertEqual(column0.index, 0)
-                XCTAssertEqual(column0.name, "id")
-                XCTAssertEqual(column0.dataType, .integer)
-                XCTAssertEqual(column0.value as? Int64, 2)
+        if columns.count == 7 {
+            let column0 = columns[0]
+            XCTAssertEqual(column0.index, 0)
+            XCTAssertEqual(column0.name, "id")
+            XCTAssertEqual(column0.dataType, .integer)
+            XCTAssertEqual(column0.value as? Int64, 2)
 
-                let column1 = columns[1]
-                XCTAssertEqual(column1.index, 1)
-                XCTAssertEqual(column1.name, "name")
-                XCTAssertEqual(column1.dataType, .text)
-                XCTAssertEqual(column1.value as? String, "Lana Kane")
+            let column1 = columns[1]
+            XCTAssertEqual(column1.index, 1)
+            XCTAssertEqual(column1.name, "name")
+            XCTAssertEqual(column1.dataType, .text)
+            XCTAssertEqual(column1.value as? String, "Lana Kane")
 
-                let column2 = columns[2]
-                XCTAssertEqual(column2.index, 2)
-                XCTAssertEqual(column2.name, "date")
-                XCTAssertEqual(column2.dataType, .text)
-                XCTAssertEqual(column2.value as? String, "2015-11-06T08:00:00.000")
+            let column2 = columns[2]
+            XCTAssertEqual(column2.index, 2)
+            XCTAssertEqual(column2.name, "date")
+            XCTAssertEqual(column2.dataType, .text)
+            XCTAssertEqual(column2.value as? String, "2015-11-06T08:00:00.000")
 
-                let column3 = columns[3]
-                XCTAssertEqual(column3.index, 3)
-                XCTAssertEqual(column3.name, "missions")
-                XCTAssertEqual(column3.dataType, .integer)
-                XCTAssertEqual(column3.value as? Int64, 2_315)
+            let column3 = columns[3]
+            XCTAssertEqual(column3.index, 3)
+            XCTAssertEqual(column3.name, "missions")
+            XCTAssertEqual(column3.dataType, .integer)
+            XCTAssertEqual(column3.value as? Int64, 2_315)
 
-                let column4 = columns[4]
-                XCTAssertEqual(column4.index, 4)
-                XCTAssertEqual(column4.name, "salary")
-                XCTAssertEqual(column4.dataType, .float)
-                XCTAssertEqual(column4.value as? Double, 9_600_200.11)
+            let column4 = columns[4]
+            XCTAssertEqual(column4.index, 4)
+            XCTAssertEqual(column4.name, "salary")
+            XCTAssertEqual(column4.dataType, .float)
+            XCTAssertEqual(column4.value as? Double, 9_600_200.11)
 
-                let column5 = columns[5]
-                XCTAssertEqual(column5.index, 5)
-                XCTAssertEqual(column5.name, "job_title")
-                XCTAssertEqual(column5.dataType, .blob)
-                XCTAssertEqual(column5.value as? Data, "Top Agent".data(using: .utf8)!)
+            let column5 = columns[5]
+            XCTAssertEqual(column5.index, 5)
+            XCTAssertEqual(column5.name, "job_title")
+            XCTAssertEqual(column5.dataType, .blob)
+            XCTAssertEqual(column5.value as? Data, "Top Agent".data(using: .utf8)!)
 
-                let column6 = columns[6]
-                XCTAssertEqual(column6.index, 6)
-                XCTAssertEqual(column6.name, "car")
-                XCTAssertEqual(column6.dataType, .null)
-                XCTAssertEqual(column6.value as? String, nil)
-            }
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+            let column6 = columns[6]
+            XCTAssertEqual(column6.index, 6)
+            XCTAssertEqual(column6.name, "car")
+            XCTAssertEqual(column6.dataType, .null)
+            XCTAssertEqual(column6.value as? String, nil)
         }
     }
 
     // MARK: - Tests - Bindings
 
-    func testThatAllNonOptionalBindingTypesCanBeAccessedByColumnIndexSubscript() {
-        do {
-            // Given, When
-            if let row = try connection.query("SELECT * FROM agents WHERE name='Lana Kane'") {
-                let id_Bool: Bool = row[0]
+    func testThatAllNonOptionalBindingTypesCanBeAccessedByColumnIndexSubscript() throws {
+        // Given, When
+        if let row = try connection.query("SELECT * FROM agents WHERE name='Lana Kane'") {
+            let id_Bool: Bool = row[0]
 
-                let id_Int8: Int8 = row[0]
-                let id_Int16: Int16 = row[0]
-                let id_Int32: Int32 = row[0]
-                let id_Int64: Int64 = row[0]
-                let id_Int: Int = row[0]
+            let id_Int8: Int8 = row[0]
+            let id_Int16: Int16 = row[0]
+            let id_Int32: Int32 = row[0]
+            let id_Int64: Int64 = row[0]
+            let id_Int: Int = row[0]
 
-                let id_UInt8: UInt8 = row[0]
-                let id_UInt16: UInt16 = row[0]
-                let id_UInt32: UInt32 = row[0]
-                let id_UInt64: UInt64 = row[0]
-                let id_UInt: UInt = row[0]
+            let id_UInt8: UInt8 = row[0]
+            let id_UInt16: UInt16 = row[0]
+            let id_UInt32: UInt32 = row[0]
+            let id_UInt64: UInt64 = row[0]
+            let id_UInt: UInt = row[0]
 
-                let salary_Float: Float = row[4]
-                let salary_Double: Double = row[4]
+            let salary_Float: Float = row[4]
+            let salary_Double: Double = row[4]
 
-                let name_String: String = row[1]
-                let date_Date: Date = row[2]
+            let name_String: String = row[1]
+            let date_Date: Date = row[2]
 
-                let jobTitle_Data: Data = row[5]
+            let jobTitle_Data: Data = row[5]
 
-                // Then
-                XCTAssertEqual(id_Bool, true)
+            // Then
+            XCTAssertEqual(id_Bool, true)
 
-                XCTAssertEqual(id_Int8, 2)
-                XCTAssertEqual(id_Int16, 2)
-                XCTAssertEqual(id_Int32, 2)
-                XCTAssertEqual(id_Int64, 2)
-                XCTAssertEqual(id_Int, 2)
+            XCTAssertEqual(id_Int8, 2)
+            XCTAssertEqual(id_Int16, 2)
+            XCTAssertEqual(id_Int32, 2)
+            XCTAssertEqual(id_Int64, 2)
+            XCTAssertEqual(id_Int, 2)
 
-                XCTAssertEqual(id_UInt8, 2)
-                XCTAssertEqual(id_UInt16, 2)
-                XCTAssertEqual(id_UInt32, 2)
-                XCTAssertEqual(id_UInt64, 2)
-                XCTAssertEqual(id_UInt, 2)
+            XCTAssertEqual(id_UInt8, 2)
+            XCTAssertEqual(id_UInt16, 2)
+            XCTAssertEqual(id_UInt32, 2)
+            XCTAssertEqual(id_UInt64, 2)
+            XCTAssertEqual(id_UInt, 2)
 
-                XCTAssertEqual(salary_Float, 9_600_200.11)
-                XCTAssertEqual(salary_Double, 9_600_200.11)
+            XCTAssertEqual(salary_Float, 9_600_200.11)
+            XCTAssertEqual(salary_Double, 9_600_200.11)
 
-                XCTAssertEqual(name_String, "Lana Kane")
-                XCTAssertEqual(date_Date, bindingDateFormatter.date(from: "2015-11-06T08:00:00.000")!)
+            XCTAssertEqual(name_String, "Lana Kane")
+            XCTAssertEqual(date_Date, bindingDateFormatter.date(from: "2015-11-06T08:00:00.000")!)
 
-                XCTAssertEqual(jobTitle_Data, "Top Agent".data(using: .utf8))
-            } else {
-                XCTFail("row should not be nil")
-            }
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+            XCTAssertEqual(jobTitle_Data, "Top Agent".data(using: .utf8))
+        } else {
+            XCTFail("row should not be nil")
         }
     }
 
-    func testThatAllOptionalBindingTypesCanBeAccessedByColumnIndexSubscript() {
-        do {
-            // Given, When
-            if let row = try connection.query("SELECT * FROM agents WHERE name='Lana Kane'") {
-                let id_Bool: Bool? = row[0]
+    func testThatAllOptionalBindingTypesCanBeAccessedByColumnIndexSubscript() throws {
+        // Given, When
+        if let row = try connection.query("SELECT * FROM agents WHERE name='Lana Kane'") {
+            let id_Bool: Bool? = row[0]
 
-                let id_Int8: Int8? = row[0]
-                let id_Int16: Int16? = row[0]
-                let id_Int32: Int32? = row[0]
-                let id_Int64: Int64? = row[0]
-                let id_Int: Int? = row[0]
+            let id_Int8: Int8? = row[0]
+            let id_Int16: Int16? = row[0]
+            let id_Int32: Int32? = row[0]
+            let id_Int64: Int64? = row[0]
+            let id_Int: Int? = row[0]
 
-                let id_UInt8: UInt8? = row[0]
-                let id_UInt16: UInt16? = row[0]
-                let id_UInt32: UInt32? = row[0]
-                let id_UInt64: UInt64? = row[0]
-                let id_UInt: UInt? = row[0]
+            let id_UInt8: UInt8? = row[0]
+            let id_UInt16: UInt16? = row[0]
+            let id_UInt32: UInt32? = row[0]
+            let id_UInt64: UInt64? = row[0]
+            let id_UInt: UInt? = row[0]
 
-                let missions_Int8: Int8? = row[3]
-                let missions_Int16: Int16? = row[3]
-                let missions_Int32: Int32? = row[3]
-                let missions_Int64: Int64? = row[3]
-                let missions_Int: Int? = row[3]
+            let missions_Int8: Int8? = row[3]
+            let missions_Int16: Int16? = row[3]
+            let missions_Int32: Int32? = row[3]
+            let missions_Int64: Int64? = row[3]
+            let missions_Int: Int? = row[3]
 
-                let missions_UInt8: UInt8? = row[3]
-                let missions_UInt16: UInt16? = row[3]
-                let missions_UInt32: UInt32? = row[3]
-                let missions_UInt64: UInt64? = row[3]
-                let missions_UInt: UInt? = row[3]
+            let missions_UInt8: UInt8? = row[3]
+            let missions_UInt16: UInt16? = row[3]
+            let missions_UInt32: UInt32? = row[3]
+            let missions_UInt64: UInt64? = row[3]
+            let missions_UInt: UInt? = row[3]
 
-                let salary_Float: Float? = row[4]
-                let salary_Double: Double? = row[4]
+            let salary_Float: Float? = row[4]
+            let salary_Double: Double? = row[4]
 
-                let name_String: String? = row[1]
-                let date_Date: Date? = row[2]
+            let name_String: String? = row[1]
+            let date_Date: Date? = row[2]
 
-                let jobTitle_Data: Data? = row[5]
+            let jobTitle_Data: Data? = row[5]
 
-                // Then
-                XCTAssertEqual(id_Bool, true)
+            // Then
+            XCTAssertEqual(id_Bool, true)
 
-                XCTAssertEqual(id_Int8, 2)
-                XCTAssertEqual(id_Int16, 2)
-                XCTAssertEqual(id_Int32, 2)
-                XCTAssertEqual(id_Int64, 2)
-                XCTAssertEqual(id_Int, 2)
+            XCTAssertEqual(id_Int8, 2)
+            XCTAssertEqual(id_Int16, 2)
+            XCTAssertEqual(id_Int32, 2)
+            XCTAssertEqual(id_Int64, 2)
+            XCTAssertEqual(id_Int, 2)
 
-                XCTAssertEqual(id_UInt8, 2)
-                XCTAssertEqual(id_UInt16, 2)
-                XCTAssertEqual(id_UInt32, 2)
-                XCTAssertEqual(id_UInt64, 2)
-                XCTAssertEqual(id_UInt, 2)
+            XCTAssertEqual(id_UInt8, 2)
+            XCTAssertEqual(id_UInt16, 2)
+            XCTAssertEqual(id_UInt32, 2)
+            XCTAssertEqual(id_UInt64, 2)
+            XCTAssertEqual(id_UInt, 2)
 
-                XCTAssertEqual(missions_Int8, nil)
-                XCTAssertEqual(missions_Int16, 2_315)
-                XCTAssertEqual(missions_Int32, 2_315)
-                XCTAssertEqual(missions_Int64, 2_315)
-                XCTAssertEqual(missions_Int, 2_315)
+            XCTAssertEqual(missions_Int8, nil)
+            XCTAssertEqual(missions_Int16, 2_315)
+            XCTAssertEqual(missions_Int32, 2_315)
+            XCTAssertEqual(missions_Int64, 2_315)
+            XCTAssertEqual(missions_Int, 2_315)
 
-                XCTAssertEqual(missions_UInt8, nil)
-                XCTAssertEqual(missions_UInt16, 2_315)
-                XCTAssertEqual(missions_UInt32, 2_315)
-                XCTAssertEqual(missions_UInt64, 2_315)
-                XCTAssertEqual(missions_UInt, 2_315)
+            XCTAssertEqual(missions_UInt8, nil)
+            XCTAssertEqual(missions_UInt16, 2_315)
+            XCTAssertEqual(missions_UInt32, 2_315)
+            XCTAssertEqual(missions_UInt64, 2_315)
+            XCTAssertEqual(missions_UInt, 2_315)
 
-                XCTAssertEqual(salary_Float, 9_600_200.11)
-                XCTAssertEqual(salary_Double, 9_600_200.11)
+            XCTAssertEqual(salary_Float, 9_600_200.11)
+            XCTAssertEqual(salary_Double, 9_600_200.11)
 
-                XCTAssertEqual(name_String, "Lana Kane")
-                XCTAssertEqual(date_Date, bindingDateFormatter.date(from: "2015-11-06T08:00:00.000")!)
+            XCTAssertEqual(name_String, "Lana Kane")
+            XCTAssertEqual(date_Date, bindingDateFormatter.date(from: "2015-11-06T08:00:00.000")!)
 
-                XCTAssertEqual(jobTitle_Data, "Top Agent".data(using: .utf8))
-            } else {
-                XCTFail("row should not be nil")
-            }
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+            XCTAssertEqual(jobTitle_Data, "Top Agent".data(using: .utf8))
+        } else {
+            XCTFail("row should not be nil")
         }
     }
 
-    func testThatAllNonOptionalBindingTypesCanBeAccessedByColumnNameSubscript() {
-        do {
-            // Given, When
-            if let row = try connection.query("SELECT * FROM agents WHERE name='Lana Kane'") {
-                let id_Bool: Bool = row["id"]
+    func testThatAllNonOptionalBindingTypesCanBeAccessedByColumnNameSubscript() throws {
+        // Given, When
+        if let row = try connection.query("SELECT * FROM agents WHERE name='Lana Kane'") {
+            let id_Bool: Bool = row["id"]
 
-                let id_Int8: Int8 = row["id"]
-                let id_Int16: Int16 = row["id"]
-                let id_Int32: Int32 = row["id"]
-                let id_Int64: Int64 = row["id"]
-                let id_Int: Int = row["id"]
+            let id_Int8: Int8 = row["id"]
+            let id_Int16: Int16 = row["id"]
+            let id_Int32: Int32 = row["id"]
+            let id_Int64: Int64 = row["id"]
+            let id_Int: Int = row["id"]
 
-                let id_UInt8: UInt8 = row["id"]
-                let id_UInt16: UInt16 = row["id"]
-                let id_UInt32: UInt32 = row["id"]
-                let id_UInt64: UInt64 = row["id"]
-                let id_UInt: UInt = row["id"]
+            let id_UInt8: UInt8 = row["id"]
+            let id_UInt16: UInt16 = row["id"]
+            let id_UInt32: UInt32 = row["id"]
+            let id_UInt64: UInt64 = row["id"]
+            let id_UInt: UInt = row["id"]
 
-                let salary_Float: Float = row["salary"]
-                let salary_Double: Double = row["salary"]
+            let salary_Float: Float = row["salary"]
+            let salary_Double: Double = row["salary"]
 
-                let name_String: String = row["name"]
-                let date_Date: Date = row["date"]
+            let name_String: String = row["name"]
+            let date_Date: Date = row["date"]
 
-                let jobTitle_Data: Data = row["job_title"]
+            let jobTitle_Data: Data = row["job_title"]
 
-                // Then
-                XCTAssertEqual(id_Bool, true)
+            // Then
+            XCTAssertEqual(id_Bool, true)
 
-                XCTAssertEqual(id_Int8, 2)
-                XCTAssertEqual(id_Int16, 2)
-                XCTAssertEqual(id_Int32, 2)
-                XCTAssertEqual(id_Int64, 2)
-                XCTAssertEqual(id_Int, 2)
+            XCTAssertEqual(id_Int8, 2)
+            XCTAssertEqual(id_Int16, 2)
+            XCTAssertEqual(id_Int32, 2)
+            XCTAssertEqual(id_Int64, 2)
+            XCTAssertEqual(id_Int, 2)
 
-                XCTAssertEqual(id_UInt8, 2)
-                XCTAssertEqual(id_UInt16, 2)
-                XCTAssertEqual(id_UInt32, 2)
-                XCTAssertEqual(id_UInt64, 2)
-                XCTAssertEqual(id_UInt, 2)
+            XCTAssertEqual(id_UInt8, 2)
+            XCTAssertEqual(id_UInt16, 2)
+            XCTAssertEqual(id_UInt32, 2)
+            XCTAssertEqual(id_UInt64, 2)
+            XCTAssertEqual(id_UInt, 2)
 
-                XCTAssertEqual(salary_Float, 9_600_200.11)
-                XCTAssertEqual(salary_Double, 9_600_200.11)
+            XCTAssertEqual(salary_Float, 9_600_200.11)
+            XCTAssertEqual(salary_Double, 9_600_200.11)
 
-                XCTAssertEqual(name_String, "Lana Kane")
-                XCTAssertEqual(date_Date, bindingDateFormatter.date(from: "2015-11-06T08:00:00.000")!)
+            XCTAssertEqual(name_String, "Lana Kane")
+            XCTAssertEqual(date_Date, bindingDateFormatter.date(from: "2015-11-06T08:00:00.000")!)
 
-                XCTAssertEqual(jobTitle_Data, "Top Agent".data(using: .utf8))
-            } else {
-                XCTFail("row should not be nil")
-            }
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+            XCTAssertEqual(jobTitle_Data, "Top Agent".data(using: .utf8))
+        } else {
+            XCTFail("row should not be nil")
         }
     }
 
-    func testThatAllOptionalBindingTypesCanBeAccessedByColumnNameSubscript() {
-        do {
-            // Given, When
-            if let row = try connection.query("SELECT * FROM agents WHERE name='Lana Kane'") {
-                let id_Bool: Bool? = row["id"]
+    func testThatAllOptionalBindingTypesCanBeAccessedByColumnNameSubscript() throws {
+        // Given, When
+        if let row = try connection.query("SELECT * FROM agents WHERE name='Lana Kane'") {
+            let id_Bool: Bool? = row["id"]
 
-                let id_Int8: Int8? = row["id"]
-                let id_Int16: Int16? = row["id"]
-                let id_Int32: Int32? = row["id"]
-                let id_Int64: Int64? = row["id"]
-                let id_Int: Int? = row["id"]
+            let id_Int8: Int8? = row["id"]
+            let id_Int16: Int16? = row["id"]
+            let id_Int32: Int32? = row["id"]
+            let id_Int64: Int64? = row["id"]
+            let id_Int: Int? = row["id"]
 
-                let id_UInt8: UInt8? = row["id"]
-                let id_UInt16: UInt16? = row["id"]
-                let id_UInt32: UInt32? = row["id"]
-                let id_UInt64: UInt64? = row["id"]
-                let id_UInt: UInt? = row["id"]
+            let id_UInt8: UInt8? = row["id"]
+            let id_UInt16: UInt16? = row["id"]
+            let id_UInt32: UInt32? = row["id"]
+            let id_UInt64: UInt64? = row["id"]
+            let id_UInt: UInt? = row["id"]
 
-                let missions_Int8: Int8? = row["missions"]
-                let missions_Int16: Int16? = row["missions"]
-                let missions_Int32: Int32? = row["missions"]
-                let missions_Int64: Int64? = row["missions"]
-                let missions_Int: Int? = row["missions"]
+            let missions_Int8: Int8? = row["missions"]
+            let missions_Int16: Int16? = row["missions"]
+            let missions_Int32: Int32? = row["missions"]
+            let missions_Int64: Int64? = row["missions"]
+            let missions_Int: Int? = row["missions"]
 
-                let missions_UInt8: UInt8? = row["missions"]
-                let missions_UInt16: UInt16? = row["missions"]
-                let missions_UInt32: UInt32? = row["missions"]
-                let missions_UInt64: UInt64? = row["missions"]
-                let missions_UInt: UInt? = row["missions"]
+            let missions_UInt8: UInt8? = row["missions"]
+            let missions_UInt16: UInt16? = row["missions"]
+            let missions_UInt32: UInt32? = row["missions"]
+            let missions_UInt64: UInt64? = row["missions"]
+            let missions_UInt: UInt? = row["missions"]
 
-                let salary_Float: Float? = row["salary"]
-                let salary_Double: Double? = row["salary"]
+            let salary_Float: Float? = row["salary"]
+            let salary_Double: Double? = row["salary"]
 
-                let name_String: String? = row["name"]
-                let date_Date: Date? = row["date"]
+            let name_String: String? = row["name"]
+            let date_Date: Date? = row["date"]
 
-                let jobTitle_Data: Data? = row["job_title"]
+            let jobTitle_Data: Data? = row["job_title"]
 
-                // Then
-                XCTAssertEqual(id_Bool, true)
+            // Then
+            XCTAssertEqual(id_Bool, true)
 
-                XCTAssertEqual(id_Int8, 2)
-                XCTAssertEqual(id_Int16, 2)
-                XCTAssertEqual(id_Int32, 2)
-                XCTAssertEqual(id_Int64, 2)
-                XCTAssertEqual(id_Int, 2)
+            XCTAssertEqual(id_Int8, 2)
+            XCTAssertEqual(id_Int16, 2)
+            XCTAssertEqual(id_Int32, 2)
+            XCTAssertEqual(id_Int64, 2)
+            XCTAssertEqual(id_Int, 2)
 
-                XCTAssertEqual(id_UInt8, 2)
-                XCTAssertEqual(id_UInt16, 2)
-                XCTAssertEqual(id_UInt32, 2)
-                XCTAssertEqual(id_UInt64, 2)
-                XCTAssertEqual(id_UInt, 2)
+            XCTAssertEqual(id_UInt8, 2)
+            XCTAssertEqual(id_UInt16, 2)
+            XCTAssertEqual(id_UInt32, 2)
+            XCTAssertEqual(id_UInt64, 2)
+            XCTAssertEqual(id_UInt, 2)
 
-                XCTAssertEqual(missions_Int8, nil)
-                XCTAssertEqual(missions_Int16, 2_315)
-                XCTAssertEqual(missions_Int32, 2_315)
-                XCTAssertEqual(missions_Int64, 2_315)
-                XCTAssertEqual(missions_Int, 2_315)
+            XCTAssertEqual(missions_Int8, nil)
+            XCTAssertEqual(missions_Int16, 2_315)
+            XCTAssertEqual(missions_Int32, 2_315)
+            XCTAssertEqual(missions_Int64, 2_315)
+            XCTAssertEqual(missions_Int, 2_315)
 
-                XCTAssertEqual(missions_UInt8, nil)
-                XCTAssertEqual(missions_UInt16, 2_315)
-                XCTAssertEqual(missions_UInt32, 2_315)
-                XCTAssertEqual(missions_UInt64, 2_315)
-                XCTAssertEqual(missions_UInt, 2_315)
+            XCTAssertEqual(missions_UInt8, nil)
+            XCTAssertEqual(missions_UInt16, 2_315)
+            XCTAssertEqual(missions_UInt32, 2_315)
+            XCTAssertEqual(missions_UInt64, 2_315)
+            XCTAssertEqual(missions_UInt, 2_315)
 
-                XCTAssertEqual(salary_Float, 9_600_200.11)
-                XCTAssertEqual(salary_Double, 9_600_200.11)
+            XCTAssertEqual(salary_Float, 9_600_200.11)
+            XCTAssertEqual(salary_Double, 9_600_200.11)
 
-                XCTAssertEqual(name_String, "Lana Kane")
-                XCTAssertEqual(date_Date, bindingDateFormatter.date(from: "2015-11-06T08:00:00.000")!)
+            XCTAssertEqual(name_String, "Lana Kane")
+            XCTAssertEqual(date_Date, bindingDateFormatter.date(from: "2015-11-06T08:00:00.000")!)
 
-                XCTAssertEqual(jobTitle_Data, "Top Agent".data(using: .utf8))
-            } else {
-                XCTFail("row should not be nil")
-            }
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+            XCTAssertEqual(jobTitle_Data, "Top Agent".data(using: .utf8))
+        } else {
+            XCTFail("row should not be nil")
         }
     }
 
     // MARK: - Tests - Values
 
-    func testThatAllDatabaseTypesCanBeAccessedThroughValuesProperty() {
-        do {
-            // Given, When
-            if
-                let values = try connection.query("SELECT * FROM agents WHERE name='Lana Kane'")?.values,
-                values.count == 7
-            {
-                // Then
-                XCTAssertTrue(values[0] is Int64, "id column should be extracted as `Int64`")
-                XCTAssertTrue(values[1] is String, "name column should be extracted as `Int64`")
-                XCTAssertTrue(values[2] is String, "date column should be extracted as `Int64`")
-                XCTAssertTrue(values[3] is Int64, "missions column should be extracted as `Int64`")
-                XCTAssertTrue(values[4] is Double, "salary column should be extracted as `Int64`")
-                XCTAssertTrue(values[5] is Data, "job_title column should be extracted as `Int64`")
-                XCTAssertNil(values[6], "car column should be extracted as `nil`")
-            } else {
-                XCTFail("values should not be nil and should have a count of 7")
-            }
-        } catch {
-            XCTFail("Test encountered unexpected error: \(error)")
+    func testThatAllDatabaseTypesCanBeAccessedThroughValuesProperty() throws {
+        // Given, When
+        if
+            let values = try connection.query("SELECT * FROM agents WHERE name='Lana Kane'")?.values,
+            values.count == 7
+        {
+            // Then
+            XCTAssertTrue(values[0] is Int64)
+            XCTAssertTrue(values[1] is String)
+            XCTAssertTrue(values[2] is String)
+            XCTAssertTrue(values[3] is Int64)
+            XCTAssertTrue(values[4] is Double)
+            XCTAssertTrue(values[5] is Data)
+            XCTAssertNil(values[6])
+        } else {
+            XCTFail("values should not be nil and should have a count of 7")
         }
     }
 }


### PR DESCRIPTION
This PR updates the test suite by replacing `do-catch` blocks with the `throws` test API variants. It also removes any unnecessary assertion description strings.