### PR TITLE
Release - Prepping 3.3.0 Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 #### 3.x Releases
 
+- `3.3.x` Releases - [3.3.0](#330)
 - `3.2.x` Releases - [3.2.0](#320) | | [3.2.1](#321) 
 - `3.1.x` Releases - [3.1.0](#310)
 - `3.0.x` Releases - [3.0.0](#300) | [3.0.1](#301)
@@ -30,6 +31,19 @@ All notable changes to this project will be documented in this file.
 - `0.3.x` Releases - [0.3.0](#030)
 - `0.2.x` Releases - [0.2.0](#020)
 - `0.1.x` Releases - [0.1.0](#010)
+
+---
+
+## [3.3.0](https://github.com/Nike-Inc/SQift/releases/tag/3.3.0)
+
+Released on 2018-11-30. All issues associated with this milestone can be found using this
+[filter](https://github.com/Nike-Inc/SQift/milestone/5?closed=1).
+
+#### Deprecated
+
+- The `trace` API to prepare for 4.0 migration since the internal `sqlite3_trace` API is deprecated when bumping deployment targets.
+  - Deprecated by [Christian Noon](https://github.com/cnoon) in Pull Request
+  [#15](https://github.com/Nike-Inc/SQift/pull/15).
 
 ---
 

--- a/SQift.podspec
+++ b/SQift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "SQift"
-  s.version = "3.2.1"
+  s.version = "3.3.0"
   s.license = "MIT"
   s.summary = "A lightweight Swift wrapper for SQLite."
   s.homepage = "https://github.com/Nike-Inc/SQift"

--- a/Source/Connection/Functions/Trace.swift
+++ b/Source/Connection/Functions/Trace.swift
@@ -146,6 +146,7 @@ extension Connection {
     /// For more details, please refer to the [documentation](https://www.sqlite.org/c3ref/profile.html).
     ///
     /// - Parameter closure: The closure called when SQLite internally calls step on a statement.
+    @available(*, deprecated: 3.3, message: "The `trace` API will be removed in SQift 4.0. Please use `traceEvent` instead.")
     public func trace(_ closure: ((String) -> Void)?) {
         guard let closure = closure else {
             sqlite3_trace(handle, nil, nil)

--- a/Source/Supporting Files/Info-tvOS.plist
+++ b/Source/Supporting Files/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.2.1</string>
+	<string>3.3.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Supporting Files/Info.plist
+++ b/Source/Supporting Files/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.2.1</string>
+	<string>3.3.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
This PR deprecates the `trace` method to allow us to cleanly remove it in SQift 4.0 since we're going to be bumping deployment targets.