### PR TITLE
Prepare SQift 4.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 os: osx
-osx_image: xcode10
+osx_image: xcode10.1
 branches:
   only:
     - master
@@ -14,13 +14,12 @@ env:
   - TVOS_FRAMEWORK_SCHEME="SQift tvOS CI"
   - WATCHOS_FRAMEWORK_SCHEME="SQift watchOS"
   matrix:
-    - DESTINATION="OS=12.0,name=iPhone XS"                  SCHEME="$IOS_FRAMEWORK_SCHEME"     RUN_TESTS="YES" BUILD_EXAMPLE="YES" POD_LINT="YES"
+    - DESTINATION="OS=12.1,name=iPhone XS"                  SCHEME="$IOS_FRAMEWORK_SCHEME"     RUN_TESTS="YES" BUILD_EXAMPLE="YES" POD_LINT="YES"
     - DESTINATION="OS=11.3,name=iPhone X"                   SCHEME="$IOS_FRAMEWORK_SCHEME"     RUN_TESTS="YES" BUILD_EXAMPLE="YES" POD_LINT="NO"
     - DESTINATION="OS=10.3.1,name=iPhone 7"                 SCHEME="$IOS_FRAMEWORK_SCHEME"     RUN_TESTS="YES" BUILD_EXAMPLE="YES" POD_LINT="NO"
-    - DESTINATION="OS=9.3,name=iPhone 4S"                   SCHEME="$IOS_FRAMEWORK_SCHEME"     RUN_TESTS="YES" BUILD_EXAMPLE="YES" POD_LINT="NO"
     - DESTINATION="arch=x86_64"                             SCHEME="$MACOS_FRAMEWORK_SCHEME"   RUN_TESTS="YES" BUILD_EXAMPLE="NO"  POD_LINT="NO"
-    - DESTINATION="OS=12.0,name=Apple TV 4K"                SCHEME="$TVOS_FRAMEWORK_SCHEME"    RUN_TESTS="YES" BUILD_EXAMPLE="NO"  POD_LINT="NO"
-    - DESTINATION="OS=5.0,name=Apple Watch Series 4 - 44mm" SCHEME="$WATCHOS_FRAMEWORK_SCHEME" RUN_TESTS="NO"  BUILD_EXAMPLE="NO"  POD_LINT="NO"
+    - DESTINATION="OS=12.1,name=Apple TV 4K"                SCHEME="$TVOS_FRAMEWORK_SCHEME"    RUN_TESTS="YES" BUILD_EXAMPLE="NO"  POD_LINT="NO"
+    - DESTINATION="OS=5.1,name=Apple Watch Series 4 - 44mm" SCHEME="$WATCHOS_FRAMEWORK_SCHEME" RUN_TESTS="NO"  BUILD_EXAMPLE="NO"  POD_LINT="NO"
 
 before_install:
   - gem update bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,17 +40,20 @@ All notable changes to this project will be documented in this file.
 
 ## [4.0.0](https://github.com/Nike-Inc/SQift/releases/tag/4.0.0)
 
+Release on 2018-11-30.  All issues associated with this milestone can be found using this
+[filter](https://github.com/Nike-Inc/SQift/milestone/7?closed=1)
+
 #### Added
 - Migration Guide for SQift 4 and added it to the README.
-  - Added by [Jereme Claussen](https://github.com/jereme)
+  - Added by [Jereme Claussen](https://github.com/jereme) in Pull Request [#16](https://github.com/Nike-Inc/SQift/pull/16).
 
 #### Updated
 - Deployment targets to iOS 9.0, Mac OSX 10.11, WatchOS 2.0 and tvOS 9.0.
-  - Added by [Jereme Claussen](https://github.com/jereme)
+  - Updated by [Jereme Claussen](https://github.com/jereme) in Pull Request [#16](https://github.com/Nike-Inc/SQift/pull/16).
   
 #### Removed
 - `Connection.trace` in favor of `Connection.traceEvent()`
-  - Added by [Jereme Claussen](https://github.com/jereme)
+  - Removed by [Jereme Claussen](https://github.com/jereme) in Pull Request [#16](https://github.com/Nike-Inc/SQift/pull/16).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 All notable changes to this project will be documented in this file.
 `SQift` adheres to [Semantic Versioning](http://semver.org/).
 
+#### 4.x Releases
+
+- `4.0.x` Releases - [4.0.0](#400)
+
 #### 3.x Releases
 
 - `3.3.x` Releases - [3.3.0](#330)
@@ -31,6 +35,22 @@ All notable changes to this project will be documented in this file.
 - `0.3.x` Releases - [0.3.0](#030)
 - `0.2.x` Releases - [0.2.0](#020)
 - `0.1.x` Releases - [0.1.0](#010)
+
+---
+
+## [4.0.0](https://github.com/Nike-Inc/SQift/releases/tag/4.0.0)
+
+#### Added
+- Migration Guide for SQift 4 and added it to the README.
+  - Added by [Jereme Claussen](https://github.com/jereme)
+
+#### Updated
+- Deployment targets to iOS 9.0, Mac OSX 10.11, WatchOS 2.0 and tvOS 9.0.
+  - Added by [Jereme Claussen](https://github.com/jereme)
+  
+#### Removed
+- `Connection.trace` in favor of `Connection.traceEvent()`
+  - Added by [Jereme Claussen](https://github.com/jereme)
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -29,9 +29,13 @@ SQift is a lightweight Swift wrapper for SQLite.
 
 ## Requirements
 
-- iOS 9.0+, macOS 10.11+, tvOS 9.0+, watchOS 2.0+
+- iOS 10.0+, macOS 10.12+, tvOS 10.0+, watchOS 3.0+
 - Xcode 9.3+
 - Swift 4.1+
+
+## Migration Guides
+
+- [SQift 4.0 Migration Guide](Documentation/SQift%204.0%20Migration%20Guide.md)
 
 ## Communication
 
@@ -86,7 +90,7 @@ $ brew install carthage
 To integrate SQift into your Xcode project using Carthage, specify it in your [Cartfile](https://github.com/Carthage/Carthage/blob/master/Documentation/Artifacts.md#cartfile):
 
 ```
-github "Nike-Inc/SQift" ~> 3.0
+github "Nike-Inc/SQift" ~> 4.0
 ```
 
 Run `carthage update` to build the framework and drag the built `SQift.framework` into your Xcode project.
@@ -487,13 +491,15 @@ try connection.transaction {
 ### Tracing
 
 When debugging SQL statements, sometimes it can be helpful to be able to print out what is actually being executed by SQLite.
-SQift allows you to do this through the `trace`and `traceEvent` APIs by registering a closure to run for each statement execution.
+SQift allows you to do this through the `traceEvent` API by registering a closure to run for each statement execution.
 
 ```swift
 let connection = try Connection(storageLocation: storageLocation)
 
-connection.trace { sql in
-    print(sql)
+connection.traceEvent { event in
+    if case .statement(_, let sql) = sql {
+        print(sql)
+    }
 }
 
 try connection.execute("CREATE TABLE employees(id INTEGER PRIMARY KEY, name TEXT)")

--- a/SQift 4.0 Migration Guide.md
+++ b/SQift 4.0 Migration Guide.md
@@ -1,0 +1,68 @@
+#  SQift 4.0 Migration Guide
+
+SQift 4.0 is the latest major release of SQift, a lightweight Swift wrapper for SQLite.  As a major release following Semantic Versioning
+conventions, 4.0 introduces multiple API-breaking changes that one should be aware of.
+
+This guide is provided in order to ease the transition of existing applications using SQift 3.x to the latest APIs, as well as explain the
+design and structure of new and changed functionality.
+
+## Requirements
+
+SQift 4.0 officially supports iOS 10.0+, macOS 10.12+, tvOS 10.0+, watchOS 3.0+, Xcode 9.3+ and Swift 4.1.
+
+## Why a Major Bump?
+
+With the introduction of watchOS 5.0, applications are no longer able to consumer frameworks with a deployment target of less than 3.0.
+This exposes SQift's use of APIs that SQlite3 has slated for deprecation.  It seemed best at this point, to bring all deployment targets up
+one major revision and fully deprecate the use older APIs.
+
+---
+
+## Breaking API Changes
+
+SQift 4.0 contains a very minor breaking change with how tracing can be performed.
+
+### Event Tracing
+
+With SQlite3's deprecation of the `sqlite3_trace` API, so goes SQift's `Connection.trace()` method.  Instead you must leverage
+the `traceEvent` API, which will require a little bit of extra code to achieve your previous results.
+
+In SQift 3.2, you could trace the execution of SQL statements simply with code similar to the following:
+
+```swift
+let connection = try Connection(storageLocation: storageLocation)
+
+connection.trace { sql in
+    print(sql)
+}
+```
+
+In SQift 4.0, you will use the `traceEvent()` API, which returns a different type of object internally.  You would write the above example as:
+
+```swift
+let connection = try Connection(storageLocation: storageLocation)
+
+connection.traceEvent { event in
+    if case .statement(_, let sql) = sql {
+        print(sql)
+    }
+}
+```
+
+In addition to this, you can pass a mask into `traceEvent` to restrict which event types are traced.  The default mask is:
+
+```swift
+UInt32(SQLITE_TRACE_STMT | SQLITE_TRACE_PROFILE | SQLITE_TRACE_ROW | SQLITE_TRACE_CLOSE)`
+```
+
+If you wanted to only trace statements, your code would look like:
+
+```swift
+let connection = try Connection(storageLocation: storageLocation)
+
+connection.traceEvent(mask: Connection.TraceEvent.statementMask) { event in
+    if case .statement(_, let sql) = sql {
+        print(sql)
+    }
+}
+```

--- a/SQift.podspec
+++ b/SQift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name = "SQift"
-  s.version = "3.3.0"
+  s.version = "4.0.0"
   s.license = "MIT"
   s.summary = "A lightweight Swift wrapper for SQLite."
   s.homepage = "https://github.com/Nike-Inc/SQift"
@@ -10,10 +10,10 @@ Pod::Spec.new do |s|
   s.source_files = "Source/**/*.swift"
   s.swift_version = "4.2"
 
-  s.ios.deployment_target = "9.0"
-  s.osx.deployment_target = "10.11"
-  s.tvos.deployment_target = "9.0"
-  s.watchos.deployment_target = "2.0"
+  s.ios.deployment_target = "10.0"
+  s.osx.deployment_target = "10.12"
+  s.tvos.deployment_target = "10.0"
+  s.watchos.deployment_target = "3.0"
 
   s.libraries = "sqlite3"
 end

--- a/SQift.xcodeproj/project.pbxproj
+++ b/SQift.xcodeproj/project.pbxproj
@@ -228,6 +228,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1E65A75F21B1C19C007F75F3 /* SQift 4.0 Migration Guide.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = "SQift 4.0 Migration Guide.md"; sourceTree = "<group>"; };
 		4C13EF9E1F7C116D0069CF58 /* ProcessInfoExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProcessInfoExtension.swift; sourceTree = "<group>"; };
 		4C29B2E41BFB25C00086A2EF /* SQift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SQift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4C29B2ED1BFB25C00086A2EF /* SQift Tests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = "SQift Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -608,6 +609,7 @@
 			children = (
 				4CE5E8691F59E89700D47037 /* CHANGELOG.md */,
 				4CE5E86A1F59E89700D47037 /* README.md */,
+				1E65A75F21B1C19C007F75F3 /* SQift 4.0 Migration Guide.md */,
 			);
 			name = Documentation;
 			sourceTree = "<group>";
@@ -1188,6 +1190,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				OTHER_LDFLAGS = "-lsqlite3";
 				PRODUCT_BUNDLE_IDENTIFIER = com.nike.SQift;
 				PRODUCT_NAME = SQift;
@@ -1215,6 +1218,7 @@
 					"@executable_path/../Frameworks",
 					"@loader_path/Frameworks",
 				);
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				OTHER_LDFLAGS = "-lsqlite3";
 				PRODUCT_BUNDLE_IDENTIFIER = com.nike.SQift;
 				PRODUCT_NAME = SQift;
@@ -1286,6 +1290,7 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 10.0;
 			};
 			name = Debug;
 		};
@@ -1312,6 +1317,7 @@
 				SDKROOT = appletvos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 10.0;
 			};
 			name = Release;
 		};
@@ -1331,6 +1337,7 @@
 				PRODUCT_NAME = "SQift Tests";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = appletvos;
+				TVOS_DEPLOYMENT_TARGET = 10.0;
 			};
 			name = Debug;
 		};
@@ -1350,6 +1357,7 @@
 				PRODUCT_NAME = "SQift Tests";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = appletvos;
+				TVOS_DEPLOYMENT_TARGET = 10.0;
 			};
 			name = Release;
 		};
@@ -1380,6 +1388,7 @@
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
 			name = Debug;
 		};
@@ -1406,6 +1415,7 @@
 				SDKROOT = watchos;
 				SKIP_INSTALL = YES;
 				TARGETED_DEVICE_FAMILY = 4;
+				WATCHOS_DEPLOYMENT_TARGET = 3.0;
 			};
 			name = Release;
 		};
@@ -1470,8 +1480,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -1526,8 +1536,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.12;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -1558,6 +1568,7 @@
 				);
 				INFOPLIST_FILE = "Source/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -1582,6 +1593,7 @@
 				GCC_PREPROCESSOR_DEFINITIONS = "SQLITE_HAS_CODEC=1";
 				INFOPLIST_FILE = "Source/Supporting Files/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Source/Connection/Functions/Function.swift
+++ b/Source/Connection/Functions/Function.swift
@@ -364,12 +364,7 @@ extension Connection {
                 data.withUnsafeBytes { sqlite3_result_blob64(context, $0, UInt64(data.count), SQLITE_TRANSIENT) }
 
             case .zeroData(let length):
-                if #available(iOS 10.0, macOS 10.12.0, tvOS 10.0, watchOS 3.0, *) {
-                    sqlite3_result_zeroblob64(context, length)
-                } else {
-                    let clampedLength = Int32(exactly: length) ?? Int32.max
-                    sqlite3_result_zeroblob(context, clampedLength)
-                }
+                sqlite3_result_zeroblob64(context, length)
 
             case .error(let message, let code):
                 sqlite3_result_error(context, message, Int32(message.utf8.count))

--- a/Source/Connection/Functions/Trace.swift
+++ b/Source/Connection/Functions/Trace.swift
@@ -33,7 +33,6 @@ extension Connection {
     ///
     /// - connectionClosed: Invoked when a database connection closes. The `connection` is a pointer to the database
     ///                     connection.
-    @available(iOS 10.0, macOS 10.12.0, tvOS 10.0, watchOS 3.0, *)
     public enum TraceEvent: CustomStringConvertible {
         case statement(statement: String, sql: SQL)
         case profile(statement: String, seconds: Double)
@@ -83,7 +82,6 @@ extension Connection {
         }
     }
 
-    @available(iOS 10.0, macOS 10.12.0, tvOS 10.0, watchOS 3.0, *)
     private class TraceEventBox {
         let closure: (TraceEvent) -> Void
 
@@ -139,35 +137,6 @@ extension Connection {
         }
     }
 
-    // MARK: - Tracing
-
-    /// Registers the callback with SQLite to be called each time a statement calls step.
-    ///
-    /// For more details, please refer to the [documentation](https://www.sqlite.org/c3ref/profile.html).
-    ///
-    /// - Parameter closure: The closure called when SQLite internally calls step on a statement.
-    @available(*, deprecated: 3.3, message: "The `trace` API will be removed in SQift 4.0. Please use `traceEvent` instead.")
-    public func trace(_ closure: ((String) -> Void)?) {
-        guard let closure = closure else {
-            sqlite3_trace(handle, nil, nil)
-            traceBox = nil
-            return
-        }
-
-        let box = TraceBox(closure)
-        traceBox = box
-
-        sqlite3_trace(
-            handle,
-            { (boxPointer: UnsafeMutableRawPointer?, data: UnsafePointer<Int8>?) in
-                guard let boxPointer = boxPointer else { return }
-                let box = Unmanaged<TraceBox>.fromOpaque(boxPointer).takeUnretainedValue()
-                box.trace(data)
-            },
-            Unmanaged<TraceBox>.passUnretained(box).toOpaque()
-        )
-    }
-
     /// Registers the callback with SQLite to be called each time a statement calls step.
     ///
     /// For more details, please refer to the [documentation](https://www.sqlite.org/c3ref/trace_v2.html).
@@ -175,7 +144,6 @@ extension Connection {
     /// - Parameters:
     ///   - mask:    The bitwise OR-ed mask of trace event constants.
     ///   - closure: The closure called when SQLite internally calls step on a statement.
-    @available(iOS 10.0, macOS 10.12.0, tvOS 10.0, watchOS 3.0, *)
     public func traceEvent(mask: UInt32? = nil, closure: ((TraceEvent) -> Void)?) {
         guard let closure = closure else {
             sqlite3_trace_v2(handle, 0, nil, nil)

--- a/Source/Connection/Statement.swift
+++ b/Source/Connection/Statement.swift
@@ -33,7 +33,6 @@ public class Statement {
     ///
     /// Note that this API can return `nil` if there is insufficient memory to hold the result, or if the result would
     /// exceed the maximum string length determined by the [SQLITE_LIMIT_LENGTH].
-    @available(iOS 10.0, macOS 10.12.0, tvOS 10.0, watchOS 3.0, *)
     public var expandedSQL: SQL? {
         guard let expandedSQL = sqlite3_expanded_sql(handle) else { return nil }
         return SQL(cString: expandedSQL)

--- a/Source/Supporting Files/Info-tvOS.plist
+++ b/Source/Supporting Files/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3.0</string>
+	<string>4.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Source/Supporting Files/Info.plist
+++ b/Source/Supporting Files/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>3.3.0</string>
+	<string>4.0.0</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/Tests/Tests/Connection/Functions/BusyTests.swift
+++ b/Tests/Tests/Connection/Functions/BusyTests.swift
@@ -42,7 +42,6 @@ class BusyTestCase: BaseConnectionTestCase {
         var checkpointError: Error?
 
         // When
-        let timeout: TimeInterval
 
         // CN (8/21/17) - I can't find a way around this issue. It seems that iOS 10 and 11 might have a
         // simulator bug or potentially a bug in SQLite where the timeout is actually in nanoseconds instead
@@ -52,12 +51,7 @@ class BusyTestCase: BaseConnectionTestCase {
         //
         // I also tested using `PRAGMA busy_timeout = 2000` and the same behavior is observed. I can't find
         // any information about this online which is odd, but we should really avoid using this in production.
-        if #available(iOS 10.0, macOS 10.12, tvOS 10.0, *) {
-            timeout = 20_000.0
-            // try connection.execute("PRAGMA busy_timeout = 2000")
-        } else {
-            timeout = 2.0
-        }
+        let timeout: TimeInterval = 20_000.0
 
         try connection.busyHandler(.timeout(timeout)) // throws SQLITE_BUSY error if this is disabled
 

--- a/Tests/Tests/Connection/Functions/TraceTests.swift
+++ b/Tests/Tests/Connection/Functions/TraceTests.swift
@@ -14,121 +14,117 @@ import XCTest
 
 class TraceTestCase: BaseTestCase {
     func testThatConnectionCanTraceStatementEventExecution() throws {
-        if #available(iOS 10.0, macOS 10.12.0, tvOS 10.0, watchOS 3.0, *) {
-            // Given
-            var connection: Connection? = try Connection(storageLocation: storageLocation)
+        // Given
+        var connection: Connection? = try Connection(storageLocation: storageLocation)
 
-            let mask = (
-                Connection.TraceEvent.statementMask |
-                Connection.TraceEvent.profileMask |
-                Connection.TraceEvent.rowMask |
-                Connection.TraceEvent.connectionClosedMask
-            )
+        let mask = (
+            Connection.TraceEvent.statementMask |
+            Connection.TraceEvent.profileMask |
+            Connection.TraceEvent.rowMask |
+            Connection.TraceEvent.connectionClosedMask
+        )
 
-            var traceEvents: [Connection.TraceEvent] = []
+        var traceEvents: [Connection.TraceEvent] = []
 
-            // When
-            connection?.traceEvent(mask: mask) { event in
-                traceEvents.append(event)
+        // When
+        connection?.traceEvent(mask: mask) { event in
+            traceEvents.append(event)
+        }
+
+        try connection?.execute("CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT)")
+        try connection?.prepare("INSERT INTO agents VALUES(?, ?)").bind(1, "Sterling Archer").run()
+        try connection?.prepare("INSERT INTO agents VALUES(?, ?)").bind(2, "Lana Kane").run()
+        try connection?.stepAll("SELECT * FROM agents")
+
+        connection = nil
+
+        // Then
+        if traceEvents.count == 11 {
+            XCTAssertEqual(traceEvents[0].rawValue, "Statement")
+            XCTAssertEqual(traceEvents[1].rawValue, "Profile")
+            XCTAssertEqual(traceEvents[2].rawValue, "Statement")
+            XCTAssertEqual(traceEvents[3].rawValue, "Profile")
+            XCTAssertEqual(traceEvents[4].rawValue, "Statement")
+            XCTAssertEqual(traceEvents[5].rawValue, "Profile")
+            XCTAssertEqual(traceEvents[6].rawValue, "Statement")
+            XCTAssertEqual(traceEvents[7].rawValue, "Row")
+            XCTAssertEqual(traceEvents[8].rawValue, "Row")
+            XCTAssertEqual(traceEvents[9].rawValue, "Profile")
+            XCTAssertEqual(traceEvents[10].rawValue, "ConnectionClosed")
+
+            if case let .statement(statement, sql) = traceEvents[0] {
+                XCTAssertEqual(statement, "CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT)")
+                XCTAssertEqual(sql, "CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT)")
             }
 
-            try connection?.execute("CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT)")
-            try connection?.prepare("INSERT INTO agents VALUES(?, ?)").bind(1, "Sterling Archer").run()
-            try connection?.prepare("INSERT INTO agents VALUES(?, ?)").bind(2, "Lana Kane").run()
-            try connection?.stepAll("SELECT * FROM agents")
-
-            connection = nil
-
-            // Then
-            if traceEvents.count == 11 {
-                XCTAssertEqual(traceEvents[0].rawValue, "Statement")
-                XCTAssertEqual(traceEvents[1].rawValue, "Profile")
-                XCTAssertEqual(traceEvents[2].rawValue, "Statement")
-                XCTAssertEqual(traceEvents[3].rawValue, "Profile")
-                XCTAssertEqual(traceEvents[4].rawValue, "Statement")
-                XCTAssertEqual(traceEvents[5].rawValue, "Profile")
-                XCTAssertEqual(traceEvents[6].rawValue, "Statement")
-                XCTAssertEqual(traceEvents[7].rawValue, "Row")
-                XCTAssertEqual(traceEvents[8].rawValue, "Row")
-                XCTAssertEqual(traceEvents[9].rawValue, "Profile")
-                XCTAssertEqual(traceEvents[10].rawValue, "ConnectionClosed")
-
-                if case let .statement(statement, sql) = traceEvents[0] {
-                    XCTAssertEqual(statement, "CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT)")
-                    XCTAssertEqual(sql, "CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT)")
-                }
-
-                if case let .profile(statement, seconds) = traceEvents[1] {
-                    XCTAssertEqual(statement, "CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT)")
-                    XCTAssertGreaterThanOrEqual(seconds, 0.0)
-                }
-
-                if case let .statement(statement, sql) = traceEvents[2] {
-                    XCTAssertEqual(statement, "INSERT INTO agents VALUES(1, \'Sterling Archer\')")
-                    XCTAssertEqual(sql, "INSERT INTO agents VALUES(?, ?)")
-                }
-
-                if case let .profile(statement, seconds) = traceEvents[3] {
-                    XCTAssertEqual(statement, "INSERT INTO agents VALUES(1, \'Sterling Archer\')")
-                    XCTAssertGreaterThanOrEqual(seconds, 0.0)
-                }
-
-                if case let .statement(statement, sql) = traceEvents[4] {
-                    XCTAssertEqual(statement, "INSERT INTO agents VALUES(2, \'Lana Kane\')")
-                    XCTAssertEqual(sql, "INSERT INTO agents VALUES(?, ?)")
-                }
-
-                if case let .profile(statement, seconds) = traceEvents[5] {
-                    XCTAssertEqual(statement, "INSERT INTO agents VALUES(2, \'Lana Kane\')")
-                    XCTAssertGreaterThanOrEqual(seconds, 0.0)
-                }
-
-                if case let .statement(statement, sql) = traceEvents[6] {
-                    XCTAssertEqual(statement, "SELECT * FROM agents")
-                    XCTAssertEqual(sql, "SELECT * FROM agents")
-                }
-
-                if case let .row(statement) = traceEvents[7] {
-                    XCTAssertEqual(statement, "SELECT * FROM agents")
-                }
-
-                if case let .row(statement) = traceEvents[8] {
-                    XCTAssertEqual(statement, "SELECT * FROM agents")
-                }
-
-                if case let .profile(statement, seconds) = traceEvents[9] {
-                    XCTAssertEqual(statement, "SELECT * FROM agents")
-                    XCTAssertGreaterThanOrEqual(seconds, 0.0)
-                }
-            } else {
-                XCTFail("traceEvents count should be 11")
+            if case let .profile(statement, seconds) = traceEvents[1] {
+                XCTAssertEqual(statement, "CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT)")
+                XCTAssertGreaterThanOrEqual(seconds, 0.0)
             }
+
+            if case let .statement(statement, sql) = traceEvents[2] {
+                XCTAssertEqual(statement, "INSERT INTO agents VALUES(1, \'Sterling Archer\')")
+                XCTAssertEqual(sql, "INSERT INTO agents VALUES(?, ?)")
+            }
+
+            if case let .profile(statement, seconds) = traceEvents[3] {
+                XCTAssertEqual(statement, "INSERT INTO agents VALUES(1, \'Sterling Archer\')")
+                XCTAssertGreaterThanOrEqual(seconds, 0.0)
+            }
+
+            if case let .statement(statement, sql) = traceEvents[4] {
+                XCTAssertEqual(statement, "INSERT INTO agents VALUES(2, \'Lana Kane\')")
+                XCTAssertEqual(sql, "INSERT INTO agents VALUES(?, ?)")
+            }
+
+            if case let .profile(statement, seconds) = traceEvents[5] {
+                XCTAssertEqual(statement, "INSERT INTO agents VALUES(2, \'Lana Kane\')")
+                XCTAssertGreaterThanOrEqual(seconds, 0.0)
+            }
+
+            if case let .statement(statement, sql) = traceEvents[6] {
+                XCTAssertEqual(statement, "SELECT * FROM agents")
+                XCTAssertEqual(sql, "SELECT * FROM agents")
+            }
+
+            if case let .row(statement) = traceEvents[7] {
+                XCTAssertEqual(statement, "SELECT * FROM agents")
+            }
+
+            if case let .row(statement) = traceEvents[8] {
+                XCTAssertEqual(statement, "SELECT * FROM agents")
+            }
+
+            if case let .profile(statement, seconds) = traceEvents[9] {
+                XCTAssertEqual(statement, "SELECT * FROM agents")
+                XCTAssertGreaterThanOrEqual(seconds, 0.0)
+            }
+        } else {
+            XCTFail("traceEvents count should be 11")
         }
     }
 
     func testThatConnectionCanTraceStatementEventExecutionUsingMask() throws {
-        if #available(iOS 10.0, macOS 10.12.0, tvOS 10.0, watchOS 3.0, *) {
-            // Given
-            var connection: Connection? = try Connection(storageLocation: storageLocation)
-            var traceEvents: [Connection.TraceEvent] = []
+        // Given
+        var connection: Connection? = try Connection(storageLocation: storageLocation)
+        var traceEvents: [Connection.TraceEvent] = []
 
-            let mask = Connection.TraceEvent.statementMask | Connection.TraceEvent.profileMask
+        let mask = Connection.TraceEvent.statementMask | Connection.TraceEvent.profileMask
 
-            // When
-            connection?.traceEvent(mask: mask) { event in
-                traceEvents.append(event)
-            }
-
-            try connection?.execute("CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT)")
-            try connection?.prepare("INSERT INTO agents VALUES(?, ?)").bind(1, "Sterling Archer").run()
-            try connection?.prepare("INSERT INTO agents VALUES(?, ?)").bind(2, "Lana Kane").run()
-            try connection?.stepAll("SELECT * FROM agents")
-
-            connection = nil
-
-            // Then
-            XCTAssertEqual(traceEvents.count, 8)
+        // When
+        connection?.traceEvent(mask: mask) { event in
+            traceEvents.append(event)
         }
+
+        try connection?.execute("CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT)")
+        try connection?.prepare("INSERT INTO agents VALUES(?, ?)").bind(1, "Sterling Archer").run()
+        try connection?.prepare("INSERT INTO agents VALUES(?, ?)").bind(2, "Lana Kane").run()
+        try connection?.stepAll("SELECT * FROM agents")
+
+        connection = nil
+
+        // Then
+        XCTAssertEqual(traceEvents.count, 8)
     }
 }
 

--- a/Tests/Tests/Connection/Functions/TraceTests.swift
+++ b/Tests/Tests/Connection/Functions/TraceTests.swift
@@ -13,35 +13,6 @@ import Foundation
 import XCTest
 
 class TraceTestCase: BaseTestCase {
-    func testThatConnectionCanTraceStatementExecution() throws {
-        // Given
-        let connection = try Connection(storageLocation: storageLocation)
-
-        var statements: [String] = []
-
-        // When
-        connection.trace { SQL in
-            statements.append(SQL)
-        }
-
-        try connection.execute("CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT)")
-        try connection.prepare("INSERT INTO agents VALUES(?, ?)").bind(1, "Sterling Archer").run()
-        try connection.prepare("INSERT INTO agents VALUES(?, ?)").bind(2, "Lana Kane").run()
-        try connection.stepAll("SELECT * FROM agents")
-
-        connection.trace(nil)
-
-        // Then
-        if statements.count == 4 {
-            XCTAssertEqual(statements[0], "CREATE TABLE agents(id INTEGER PRIMARY KEY, name TEXT)")
-            XCTAssertEqual(statements[1], "INSERT INTO agents VALUES(1, 'Sterling Archer')")
-            XCTAssertEqual(statements[2], "INSERT INTO agents VALUES(2, 'Lana Kane')")
-            XCTAssertEqual(statements[3], "SELECT * FROM agents")
-        } else {
-            XCTFail("statements count should be 4")
-        }
-    }
-
     func testThatConnectionCanTraceStatementEventExecution() throws {
         if #available(iOS 10.0, macOS 10.12.0, tvOS 10.0, watchOS 3.0, *) {
             // Given
@@ -163,7 +134,6 @@ class TraceTestCase: BaseTestCase {
 
 // MARK: -
 
-@available(iOS 10.0, macOS 10.12.0, tvOS 10.0, watchOS 3.0, *)
 extension Connection.TraceEvent {
     var rawValue: String {
         switch self {

--- a/Tests/Tests/Connection/StatementTests.swift
+++ b/Tests/Tests/Connection/StatementTests.swift
@@ -71,8 +71,6 @@ class StatementTestCase: BaseConnectionTestCase {
     }
 
     func testThatStatementCanReturnExpandedSQLBoundWithParameters() throws {
-        guard #available(iOS 10.0, macOS 10.12.0, tvOS 10.0, watchOS 3.0, *) else { return }
-
         // Given
         try connection.execute("CREATE TABLE person(id INTEGER PRIMARY KEY, first_name TEXT NOT NULL)")
 


### PR DESCRIPTION
- Updated deployment targets to iOS 10.0, macOS 10.12, tvOS 10.0, watchOS 3.0
- Removed `Connection.trace()` in favor of `Connection.traceEvent()`
- Removed all availability checks as they were for the new deployment targets.
- Added SQift 4.0 migration guide
- Updated README and CHANGELOG